### PR TITLE
Route answer responses through CachedLayer after materialize kill

### DIFF
--- a/chafan_core/app/api/api_v1/endpoints/activities.py
+++ b/chafan_core/app/api/api_v1/endpoints/activities.py
@@ -9,7 +9,7 @@ from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
 from chafan_core.app.common import report_msg
 from chafan_core.app.schemas.activity import UserFeedSettings
-from chafan_core.app.schemas.answer import AnswerPreview, AnswerPreviewForVisitor
+from chafan_core.app.schemas.answer import AnswerPreview
 from chafan_core.utils.base import unwrap
 
 
@@ -24,7 +24,7 @@ def _update_feed_seq(
 ) -> schemas.FeedSequence:
     for a in s.activities:
         if hasattr(a.event.content, "answer") and full_answers:
-            answer: Union[AnswerPreview, AnswerPreviewForVisitor] = getattr(
+            answer: AnswerPreview = getattr(
                 a.event.content, "answer"
             )
             answer.full_answer = cached_layer.get_answer(answer.uuid)

--- a/chafan_core/app/api/api_v1/endpoints/answer_suggest_edits.py
+++ b/chafan_core/app/api/api_v1/endpoints/answer_suggest_edits.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 import sentry_sdk
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 
 from chafan_core.app import crud, models, schemas
 from chafan_core.app.api import deps
 from chafan_core.app.api.api_v1.endpoints.answers import _update_answer
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, run_dramatiq_task
+from chafan_core.app.common import OperationType
 from chafan_core.app.materialize import check_user_in_site
 from chafan_core.app.schemas.answer import AnswerUpdate
 from chafan_core.app.schemas.answer_suggest_edit import (
@@ -26,6 +26,7 @@ def post_answer_suggest_edits(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     *,
     create_in: AnswerSuggestEditCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     current_user = cached_layer.get_current_active_user()
     answer = crud.answer.get_by_uuid(cached_layer.get_db(), uuid=create_in.answer_uuid)
@@ -58,7 +59,7 @@ def post_answer_suggest_edits(
     )
     from chafan_core.app.task import postprocess_new_answer_suggest_edit
 
-    run_dramatiq_task(postprocess_new_answer_suggest_edit, s.id)
+    background_tasks.add_task(postprocess_new_answer_suggest_edit, s.id)
     return unwrap(cached_layer.materializer.answer_suggest_edit_schema_from_orm(s))
 
 
@@ -81,7 +82,9 @@ def _check_suggestion_author(
 
 
 def _accept_answer_suggest_edit(
-    cached_layer: CachedLayer, answer_suggest_edit: models.AnswerSuggestEdit
+    cached_layer: CachedLayer,
+    answer_suggest_edit: models.AnswerSuggestEdit,
+    background_tasks: BackgroundTasks,
 ) -> None:
     # Update the answer
     body_rich_text = None
@@ -100,11 +103,12 @@ def _accept_answer_suggest_edit(
             is_draft=False,
             visibility=answer_suggest_edit.answer.visibility,
         ),
+        background_tasks=background_tasks,
     )
     # Rebate the suggestion author
     from chafan_core.app.task import postprocess_accept_answer_suggest_edit
 
-    run_dramatiq_task(postprocess_accept_answer_suggest_edit, answer_suggest_edit.id)
+    background_tasks.add_task(postprocess_accept_answer_suggest_edit, answer_suggest_edit.id)
 
 
 @router.put("/{uuid}", response_model=schemas.AnswerSuggestEdit)
@@ -113,6 +117,7 @@ def update_answer_suggest_edits(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     update_in: AnswerSuggestEditUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     db = cached_layer.get_db()
     current_user_id = cached_layer.unwrapped_principal_id()
@@ -154,7 +159,7 @@ def update_answer_suggest_edits(
                     answer_suggest_edit.author
                 )
             db.commit()
-            _accept_answer_suggest_edit(cached_layer, answer_suggest_edit)
+            _accept_answer_suggest_edit(cached_layer, answer_suggest_edit, background_tasks=background_tasks)
         elif new_status == "rejected":
             _check_author(answer_suggest_edit, current_user_id)
             update_dict["rejected_at"] = utc_now

--- a/chafan_core/app/api/api_v1/endpoints/answers.py
+++ b/chafan_core/app/api/api_v1/endpoints/answers.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/{uuid}", response_model=Union[schemas.Answer, schemas.AnswerForVisitor])
+@router.get("/{uuid}", response_model=schemas.Answer)
 def get_one(
     *,
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),

--- a/chafan_core/app/api/api_v1/endpoints/answers.py
+++ b/chafan_core/app/api/api_v1/endpoints/answers.py
@@ -230,7 +230,7 @@ def create_answer(
     if answer.is_published:
         logger.info(f"create_answer add postprocess task id={answer.id}")
         background_tasks.add_task(postprocess_new_answer, answer.id, False)
-    return cached_layer.materializer.answer_schema_from_orm(answer)
+    return cached_layer.answer_schema_from_orm(answer)
 
 
 def _update_answer(
@@ -282,7 +282,7 @@ def _update_answer(
         background_tasks.add_task(postprocess_new_answer, answer.id, was_published)
 
     cached_layer.invalidate_answer_cache(answer.uuid)
-    return unwrap(cached_layer.materializer.answer_schema_from_orm(answer))
+    return unwrap(cached_layer.answer_schema_from_orm(answer))
 
 
 @router.put("/{uuid}", response_model=schemas.Answer)
@@ -350,7 +350,7 @@ def update_answer_by_mod(
             status_code=400,
             detail="The answer doesn't exist in the system.",
         )
-    answer_data = cached_layer.materializer.answer_schema_from_orm(answer)
+    answer_data = cached_layer.answer_schema_from_orm(answer)
     if answer_data is None:
         raise HTTPException_(
             status_code=400,
@@ -368,7 +368,7 @@ def update_answer_by_mod(
     answer = crud.answer.update_checked(
         db, db_obj=answer, obj_in=update_in.dict(exclude_none=True)
     )
-    answer_data = cached_layer.materializer.answer_schema_from_orm(answer)
+    answer_data = cached_layer.answer_schema_from_orm(answer)
     cached_layer.invalidate_answer_cache(uuid=uuid)
     return answer_data
 

--- a/chafan_core/app/api/api_v1/endpoints/answers.py
+++ b/chafan_core/app/api/api_v1/endpoints/answers.py
@@ -1,13 +1,13 @@
 from typing import Any, List, Union
 
-from fastapi import APIRouter, Depends, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models, schemas, view_counters
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, client_ip, run_dramatiq_task
+from chafan_core.app.common import OperationType, client_ip
 from chafan_core.app.endpoint_utils import check_writing_session
 from chafan_core.app.limiter import limiter
 from chafan_core.app.materialize import (
@@ -183,6 +183,7 @@ def create_answer(
     *,
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     answer_in: schemas.AnswerCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Create new answer authored by the current user in one of the belonging sites.
@@ -228,7 +229,7 @@ def create_answer(
     )
     if answer.is_published:
         logger.info(f"create_answer add postprocess task id={answer.id}")
-        run_dramatiq_task(postprocess_new_answer, answer.id, False)
+        background_tasks.add_task(postprocess_new_answer, answer.id, False)
     return cached_layer.materializer.answer_schema_from_orm(answer)
 
 
@@ -237,6 +238,7 @@ def _update_answer(
     *,
     answer: models.Answer,
     answer_in: schemas.AnswerUpdate,
+    background_tasks: BackgroundTasks,
 ) -> schemas.Answer:
     db = cached_layer.get_db()
     answer_in_dict = answer_in.dict(exclude_none=True)
@@ -277,7 +279,7 @@ def _update_answer(
         # NOTE: Since is_published will not be reverted, thus this should only be delivered once
         # TODO: Implement the update subscription logic
 
-        run_dramatiq_task(postprocess_new_answer, answer.id, was_published)
+        background_tasks.add_task(postprocess_new_answer, answer.id, was_published)
 
     cached_layer.invalidate_answer_cache(answer.uuid)
     return unwrap(cached_layer.materializer.answer_schema_from_orm(answer))
@@ -290,6 +292,7 @@ def update_answer(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     answer_in: schemas.AnswerUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Update answer authored by current user in one of current user's belonging sites.
@@ -326,7 +329,7 @@ def update_answer(
         user_id=current_user_id,
         op_type=OperationType.WriteSiteAnswer,
     )
-    return _update_answer(cached_layer, answer=answer, answer_in=answer_in)
+    return _update_answer(cached_layer, answer=answer, answer_in=answer_in, background_tasks=background_tasks)
 
 
 @router.put("/{uuid}/mod", response_model=schemas.Answer, include_in_schema=False)

--- a/chafan_core/app/api/api_v1/endpoints/articles.py
+++ b/chafan_core/app/api/api_v1/endpoints/articles.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/{uuid}", response_model=Union[schemas.Article, schemas.ArticleForVisitor])
+@router.get("/{uuid}", response_model=schemas.Article)
 def get_article(
     request: Request,
     *,
@@ -215,7 +215,7 @@ def create_article(
         from chafan_core.app.task import postprocess_new_article
 
         background_tasks.add_task(postprocess_new_article, new_article.id)
-    data = cached_layer.materializer.article_schema_from_orm(new_article)
+    data = cached_layer.article_schema_from_orm(new_article)
     assert data is not None
     return data
 
@@ -293,7 +293,7 @@ def update_article(
         from chafan_core.app.task import postprocess_updated_article
 
         background_tasks.add_task(postprocess_updated_article, article.id, was_published)
-    data = cached_layer.materializer.article_schema_from_orm(article)
+    data = cached_layer.article_schema_from_orm(article)
     assert data is not None
     return data
 

--- a/chafan_core/app/api/api_v1/endpoints/articles.py
+++ b/chafan_core/app/api/api_v1/endpoints/articles.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, List, Optional, Union
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 from fastapi.param_functions import Query
 from sqlalchemy.orm import Session
@@ -10,7 +10,7 @@ import chafan_core
 from chafan_core.app import crud, models, schemas, view_counters
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import client_ip, run_dramatiq_task
+from chafan_core.app.common import client_ip
 from chafan_core.app.config import settings
 from chafan_core.app.endpoint_utils import check_writing_session
 from chafan_core.app.materialize import article_archive_schema_from_orm
@@ -175,6 +175,7 @@ def create_article(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     *,
     article_in: schemas.ArticleCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Create new article authored by the current user in one of the belonging sites.
@@ -213,7 +214,7 @@ def create_article(
     if new_article.is_published:
         from chafan_core.app.task import postprocess_new_article
 
-        run_dramatiq_task(postprocess_new_article, new_article.id)
+        background_tasks.add_task(postprocess_new_article, new_article.id)
     data = cached_layer.materializer.article_schema_from_orm(new_article)
     assert data is not None
     return data
@@ -226,6 +227,7 @@ def update_article(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     article_in: schemas.ArticleUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     current_user_id = cached_layer.unwrapped_principal_id()
     crud.audit_log.create_with_user(
@@ -290,7 +292,7 @@ def update_article(
     if article.is_published:
         from chafan_core.app.task import postprocess_updated_article
 
-        run_dramatiq_task(postprocess_updated_article, article.id, was_published)
+        background_tasks.add_task(postprocess_updated_article, article.id, was_published)
     data = cached_layer.materializer.article_schema_from_orm(article)
     assert data is not None
     return data

--- a/chafan_core/app/api/api_v1/endpoints/comments.py
+++ b/chafan_core/app/api/api_v1/endpoints/comments.py
@@ -33,24 +33,13 @@ def get_comment(
             status_code=400,
             detail="The comment doesn't exist in the system.",
         )
-    current_user_id = cached_layer.principal_id
-    if current_user_id:
-        if comment.site is not None:
-            check_user_in_site(
-                cached_layer.get_db(),
-                site=comment.site,
-                user_id=current_user_id,
-                op_type=OperationType.ReadSite,
-            )
-        return cached_layer.materializer.comment_schema_from_orm(comment)
-    else:
-        if comment.site is not None:
-            if not comment.site.public_readable:
-                raise HTTPException_(
-                    status_code=400,
-                    detail="Unauthorized.",
-                )
-        return cached_layer.materializer.comment_for_visitor_schema_from_orm(comment)
+    data = cached_layer.materializer.comment_schema_from_orm(comment)
+    if data is None:
+        raise HTTPException_(
+            status_code=400,
+            detail="Unauthorized.",
+        )
+    return data
 
 
 @router.get("/{uuid}/upvotes/", response_model=schemas.CommentUpvotes)

--- a/chafan_core/app/api/api_v1/endpoints/comments.py
+++ b/chafan_core/app/api/api_v1/endpoints/comments.py
@@ -1,13 +1,13 @@
 import datetime
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, BackgroundTasks
 from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models, schemas
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, run_dramatiq_task
+from chafan_core.app.common import OperationType
 from chafan_core.app.materialize import check_user_in_site
 from chafan_core.app.task import postprocess_comment_update, postprocess_new_comment
 from chafan_core.utils.base import HTTPException_
@@ -115,6 +115,7 @@ def create_comment(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     db: Session = Depends(deps.get_db),
     comment_in: schemas.CommentCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Create new comment authored by the current active user in one of the belonging sites.
@@ -147,7 +148,7 @@ def create_comment(
     comment = crud.comment.create_with_author(
         db, obj_in=comment_in, author_id=current_user_id, check_site=check_site
     )
-    run_dramatiq_task(
+    background_tasks.add_task(
         postprocess_new_comment,
         comment.id,
         comment_in.shared_to_timeline,
@@ -165,6 +166,7 @@ def update_comment(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     comment_in: schemas.CommentUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Update comment authored by the current user in one of the belonging sites.
@@ -195,7 +197,7 @@ def update_comment(
     new_comment = crud.comment.update(
         cached_layer.get_db(), db_obj=comment, obj_in=comment_in_dict
     )
-    run_dramatiq_task(
+    background_tasks.add_task(
         postprocess_comment_update,
         comment.id,
         was_shared_to_timeline,

--- a/chafan_core/app/api/api_v1/endpoints/discovery.py
+++ b/chafan_core/app/api/api_v1/endpoints/discovery.py
@@ -25,7 +25,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/pinned-questions/", response_model=List[schemas.QuestionPreviewForVisitor]
+    "/pinned-questions/", response_model=List[schemas.QuestionPreview]
 )
 def pinned_questions(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),
@@ -34,13 +34,13 @@ def pinned_questions(
     key = f"chafan:api:/discovery/pinned-questions"
     value = redis.get(key)
     if value:
-        return TypeAdapter(List[schemas.QuestionPreviewForVisitor]).validate_json(value)
+        return TypeAdapter(List[schemas.QuestionPreview]).validate_json(value)
 
-    def runnable(db: Session) -> List[schemas.QuestionPreviewForVisitor]:
+    def runnable(db: Session) -> List[schemas.QuestionPreview]:
         questions = crud.question.get_placed_at_home(db)
         data = filter_not_none(
             [
-                cached_layer.materializer.preview_of_question_for_visitor(q)
+                cached_layer.materializer.preview_of_question(q)
                 for q in questions
             ]
         )
@@ -55,7 +55,7 @@ def pinned_questions(
 
 def _get_pending_questions(
     cached_layer: CachedLayer,
-) -> Union[List[schemas.QuestionPreview], List[schemas.QuestionPreviewForVisitor]]:
+) -> List[schemas.QuestionPreview]:
     if cached_layer.principal_id:
         current_user = crud.user.get(
             cached_layer.get_db(), id=cached_layer.principal_id
@@ -74,25 +74,23 @@ def _get_pending_questions(
             )
         return questions
     else:
-        questions_for_visitors: List[schemas.QuestionPreviewForVisitor] = []
+        questions: List[schemas.QuestionPreview] = []
         for site in crud.site.get_all_public_readable(cached_layer.get_db()):
-            questions_for_visitors.extend(
+            questions.extend(
                 filter_not_none(
                     [
-                        cached_layer.materializer.preview_of_question_for_visitor(q)
+                        cached_layer.materializer.preview_of_question(q)
                         for q in site.questions
                         if len(get_live_answers_of_question(q)) == 0 and not q.is_hidden
                     ]
                 )[:10]
             )
-        return questions_for_visitors
+        return questions
 
 
 @router.get(
     "/pending-questions/",
-    response_model=Union[
-        List[schemas.QuestionPreview], List[schemas.QuestionPreviewForVisitor]
-    ],
+    response_model=List[schemas.QuestionPreview],
 )
 def get_pending_questions(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),
@@ -101,12 +99,7 @@ def get_pending_questions(
     key = f"chafan:pending-questions-for-user:{cached_layer.principal_id}"
     value = redis.get(key)
     if value is not None:
-        if cached_layer.principal_id:
-            return TypeAdapter(List[schemas.QuestionPreview]).validate_json(value)
-        else:
-            return TypeAdapter(List[schemas.QuestionPreviewForVisitor]).validate_json(
-                value
-            )
+        return TypeAdapter(List[schemas.QuestionPreview]).validate_json(value)
     data = _get_pending_questions(cached_layer)
     if not is_dev():
         redis.set(
@@ -117,9 +110,7 @@ def get_pending_questions(
 
 @router.get(
     "/interesting-questions/",
-    response_model=Union[
-        List[schemas.QuestionPreview], List[schemas.QuestionPreviewForVisitor]
-    ],
+    response_model=List[schemas.QuestionPreview],
 )
 def get_interesting_questions(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),

--- a/chafan_core/app/api/api_v1/endpoints/discovery.py
+++ b/chafan_core/app/api/api_v1/endpoints/discovery.py
@@ -127,9 +127,7 @@ def get_interesting_users(
 
 @router.get(
     "/featured-answers/",
-    response_model=Union[
-        List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]
-    ],
+    response_model=List[schemas.AnswerPreview],
 )
 def get_featured_answers(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),

--- a/chafan_core/app/api/api_v1/endpoints/feedbacks.py
+++ b/chafan_core/app/api/api_v1/endpoints/feedbacks.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, List, Optional
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request, Response, BackgroundTasks
 from fastapi.datastructures import UploadFile
 from fastapi.param_functions import File, Form
 from sqlalchemy.orm import Session
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from chafan_core.app import crud, schemas
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import run_dramatiq_task, valid_content_length
+from chafan_core.app.common import valid_content_length
 from chafan_core.app.limiter import limiter
 from chafan_core.app.models.feedback import Feedback
 from chafan_core.utils.base import HTTPException_
@@ -71,6 +71,7 @@ def post_feedback(
     email: Optional[CaseInsensitiveEmailStr] = Form(None),
     file_size: int = Depends(valid_content_length),
     current_user_id: Optional[int] = Depends(deps.try_get_current_user_id),
+    background_tasks: BackgroundTasks,
 ) -> Any:
     screenshot_blob = None
     if file:
@@ -94,5 +95,5 @@ def post_feedback(
     db.commit()
     from chafan_core.app.task import postprocess_new_feedback
 
-    run_dramatiq_task(postprocess_new_feedback, feedback.id)
+    background_tasks.add_task(postprocess_new_feedback, feedback.id)
     return schemas.GenericResponse()

--- a/chafan_core/app/api/api_v1/endpoints/people.py
+++ b/chafan_core/app/api/api_v1/endpoints/people.py
@@ -73,11 +73,20 @@ def _get_edu_exps(
     return ret
 
 
-def _get_user_public_visitor(
+def _get_user_public(
     cached_layer: CachedLayer, user: models.User, view_times: int
-) -> schemas.UserPublicForVisitor:
+) -> schemas.UserPublic:
+    """One public profile schema for any principal allowed to view the user."""
     preview = cached_layer.preview_of_user(user)
-    return schemas.UserPublicForVisitor(
+    db = cached_layer.get_db()
+    about_content = None
+    if user.about is not None:
+        about_content = RichText(source=user.about, editor="wysiwyg")
+    contributions = [
+        YearContributions(year=year, data=data)
+        for year, data in cached_layer.get_user_contributions(user)
+    ]
+    return schemas.UserPublic(
         **preview.dict(),
         gif_avatar_url=user.gif_avatar_url,
         answers_count=len(
@@ -94,12 +103,23 @@ def _get_user_public_visitor(
         ),
         created_at=user.created_at,
         profile_view_times=view_times,
+        about_content=about_content,
+        profiles=[],
+        residency_topics=[schemas.Topic.from_orm(t) for t in user.residency_topics],
+        profession_topics=[schemas.Topic.from_orm(t) for t in user.profession_topics],
+        github_username=user.github_username,
+        twitter_username=user.twitter_username,
+        linkedin_url=user.linkedin_url,
+        homepage_url=user.homepage_url,
+        zhihu_url=user.zhihu_url,
+        subscribed_topics=[schemas.Topic.from_orm(t) for t in user.subscribed_topics],
+        work_exps=_get_work_exps(db, user),
+        edu_exps=_get_edu_exps(db, user),
+        contributions=contributions,
     )
 
 
-@router.get(
-    "/{handle}", response_model=Union[schemas.UserPublic, schemas.UserPublicForVisitor]
-)
+@router.get("/{handle}", response_model=schemas.UserPublic)
 def get_user_public(
     *,
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),
@@ -115,35 +135,10 @@ def get_user_public(
             detail="The user doesn't exist in the system.",
         )
     # TODO turn it off 2025-07-23
-    view_times = 5 # view_counters.get_views(user.uuid, "profile")
-    if current_user_id is None:
-        return _get_user_public_visitor(cached_layer, user, view_times)
-    #view_counters.add_view(user.uuid, "profile", current_user_id)
-    db.commit()
-    about_content = None
-    if user.about is not None:
-        about_content = RichText(source=user.about, editor="wysiwyg")
-    u = _get_user_public_visitor(cached_layer, user, view_times)
-    contributions = [
-        YearContributions(year=year, data=data)
-        for year, data in cached_layer.get_user_contributions(user)
-    ]
-    return schemas.UserPublic(
-        **u.dict(),
-        about_content=about_content,
-        profiles=[],
-        residency_topics=[schemas.Topic.from_orm(t) for t in user.residency_topics],
-        profession_topics=[schemas.Topic.from_orm(t) for t in user.profession_topics],
-        github_username=user.github_username,
-        twitter_username=user.twitter_username,
-        linkedin_url=user.linkedin_url,
-        homepage_url=user.homepage_url,
-        zhihu_url=user.zhihu_url,
-        subscribed_topics=[schemas.Topic.from_orm(t) for t in user.subscribed_topics],
-        work_exps=_get_work_exps(db, user),
-        edu_exps=_get_edu_exps(db, user),
-        contributions=contributions,
-    )
+    view_times = 5  # view_counters.get_views(user.uuid, "profile")
+    if current_user_id is not None:
+        db.commit()
+    return _get_user_public(cached_layer, user, view_times)
 
 
 @router.get("/{uuid}/site-profiles/", response_model=List[schemas.Profile])

--- a/chafan_core/app/api/api_v1/endpoints/people.py
+++ b/chafan_core/app/api/api_v1/endpoints/people.py
@@ -266,9 +266,7 @@ def get_user_articles(
 
 @router.get(
     "/{uuid}/answers/",
-    response_model=Union[
-        List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]
-    ],
+    response_model=List[schemas.AnswerPreview],
 )
 def get_user_answers(
     *,

--- a/chafan_core/app/api/api_v1/endpoints/questions.py
+++ b/chafan_core/app/api/api_v1/endpoints/questions.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-AnswersData = Union[List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]]
+AnswersData = List[schemas.AnswerPreview]
 
 
 def _get_answers(
@@ -36,20 +36,6 @@ def _get_answers(
             [
                 cached_layer.materializer.preview_of_answer(answer)
                 for answer in question.answers
-            ]
-        ),
-        key=lambda a: a.upvotes_count,
-    )
-
-
-def _get_answers_for_visitor(
-    cached_layer: CachedLayer, question: models.Question
-) -> List[schemas.AnswerPreviewForVisitor]:
-    return sorted(
-        filter_not_none(
-            [
-                cached_layer.materializer.preview_of_answer_for_visitor(answer)
-                for answer in question.answers[:10]
             ]
         ),
         key=lambda a: a.upvotes_count,
@@ -116,9 +102,7 @@ def bump_views_counter(
 
 @router.get(
     "/{uuid}/answers/",
-    response_model=Union[
-        List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]
-    ],
+    response_model=List[schemas.AnswerPreview],
 )
 def get_question_answers(
     *,
@@ -130,21 +114,17 @@ def get_question_answers(
     Get question's answers' previews.
     """
     question = cached_layer.get_question_model_http(uuid)
-    if current_user_id is not None:
-        check_user_in_site(
-            cached_layer.get_db(),
-            site=question.site,
-            user_id=current_user_id,
-            op_type=OperationType.ReadSite,
+    if not user_in_site(
+        cached_layer.get_db(),
+        site=question.site,
+        user_id=current_user_id,
+        op_type=OperationType.ReadSite,
+    ):
+        raise HTTPException_(
+            status_code=400,
+            detail="Unauthorized.",
         )
-        return _get_answers(cached_layer, question)
-    else:
-        if not question.site.public_readable:
-            raise HTTPException_(
-                status_code=400,
-                detail="Unauthorized.",
-            )
-        return _get_answers_for_visitor(cached_layer, question)
+    return _get_answers(cached_layer, question)
 
 
 @router.post("/", response_model=schemas.Question)

--- a/chafan_core/app/api/api_v1/endpoints/questions.py
+++ b/chafan_core/app/api/api_v1/endpoints/questions.py
@@ -58,15 +58,8 @@ def _get_answers_for_visitor(
 
 def _get_question_data(
     cached_layer: CachedLayer, question: models.Question
-) -> Union[schemas.Question, schemas.QuestionForVisitor]:
-    # TODO removed the check for principle id 2025-07-23
+) -> schemas.Question:
     question_data = cached_layer.question_schema_from_orm(question)
-#    if cached_layer.principal_id is None:
-#        question_data = cached_layer.materializer.question_for_visitor_schema_from_orm(
-#            question
-#        )
-#    else:
-#        question_data = cached_layer.materializer.question_schema_from_orm(question)
     if question_data is None:
         raise HTTPException_(
             status_code=400,
@@ -76,7 +69,7 @@ def _get_question_data(
 
 
 @router.get(
-    "/{uuid}", response_model=Union[schemas.Question, schemas.QuestionForVisitor]
+    "/{uuid}", response_model=schemas.Question
 )
 @limiter.limit("60/minute")
 def get_question(
@@ -328,7 +321,7 @@ def hide_question(
     question = crud.question.update(
         cached_layer.get_db(), db_obj=question, obj_in={"is_hidden": True}
     )
-    return cached_layer.materializer.question_schema_from_orm(question)
+    return cached_layer.question_schema_from_orm(question)
 
 
 @router.post(

--- a/chafan_core/app/api/api_v1/endpoints/questions.py
+++ b/chafan_core/app/api/api_v1/endpoints/questions.py
@@ -1,13 +1,13 @@
 import datetime
 from typing import Any, List, Optional, Union
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request, Response, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 
 from chafan_core.app import crud, models, schemas, view_counters
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, client_ip, run_dramatiq_task
+from chafan_core.app.common import OperationType, client_ip
 from chafan_core.app.endpoint_utils import get_site
 from chafan_core.app.limiter import limiter
 from chafan_core.app.materialize import check_user_in_site, user_in_site
@@ -153,6 +153,7 @@ def create_question(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     *,
     question_in: schemas.QuestionCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Create new question authored by the current user in one of the belonging sites.
@@ -186,7 +187,7 @@ def create_question(
     current_user = crud.user.subscribe_question(
         db, db_obj=current_user, question=new_question
     )
-    run_dramatiq_task(postprocess_new_question, new_question.id)
+    background_tasks.add_task(postprocess_new_question, new_question.id)
     return cached_layer.question_schema_from_orm(new_question)
 
 
@@ -198,6 +199,7 @@ def update_question(
     uuid: str,
     question_in: schemas.QuestionUpdate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Update question in one of current_user's belonging sites as member.
@@ -269,7 +271,7 @@ def update_question(
         question_in_dict["description"] = None
         question_in_dict["description_text"] = None
     new_question = crud.question.update(db, db_obj=question, obj_in=question_in_dict)
-    run_dramatiq_task(postprocess_updated_question, new_question.id)
+    background_tasks.add_task(postprocess_updated_question, new_question.id)
     return cached_layer.question_schema_from_orm(new_question)
 
 

--- a/chafan_core/app/api/api_v1/endpoints/sites.py
+++ b/chafan_core/app/api/api_v1/endpoints/sites.py
@@ -225,12 +225,7 @@ def get_site_info(
     return site_data
 
 
-site_questions_T = Union[
-    List[schemas.QuestionPreview], List[schemas.QuestionPreviewForVisitor]
-]
-
-
-@router.get("/{uuid}/questions/", response_model=site_questions_T)
+@router.get("/{uuid}/questions/", response_model=List[schemas.QuestionPreview])
 def get_site_questions(
     *,
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),

--- a/chafan_core/app/api/api_v1/endpoints/sites.py
+++ b/chafan_core/app/api/api_v1/endpoints/sites.py
@@ -260,7 +260,7 @@ def get_site_questions(
 
 @router.get(
     "/{uuid}/submissions/",
-    response_model=Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]],
+    response_model=List[schemas.Submission],
 )
 def get_site_submissions(
     *,

--- a/chafan_core/app/api/api_v1/endpoints/submission_suggestions.py
+++ b/chafan_core/app/api/api_v1/endpoints/submission_suggestions.py
@@ -2,14 +2,14 @@ import datetime
 from typing import Any
 
 import sentry_sdk
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 
 from chafan_core.app import crud, models, schemas
 from chafan_core.app.api import deps
 from chafan_core.app.api.api_v1.endpoints.submissions import _update_submission
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, run_dramatiq_task
+from chafan_core.app.common import OperationType
 from chafan_core.app.materialize import check_user_in_site
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.submission import SubmissionUpdate
@@ -28,6 +28,7 @@ def post_submission_suggestions(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     *,
     create_in: SubmissionSuggestionCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     current_user = cached_layer.get_current_active_user()
     submission = crud.submission.get_by_uuid(
@@ -57,7 +58,7 @@ def post_submission_suggestions(
     )
     from chafan_core.app.task import postprocess_new_submission_suggestion
 
-    run_dramatiq_task(postprocess_new_submission_suggestion, s.id)
+    background_tasks.add_task(postprocess_new_submission_suggestion, s.id)
     return unwrap(cached_layer.materializer.submission_suggestion_schema_from_orm(s))
 
 
@@ -82,7 +83,9 @@ def _check_suggestion_author(
 
 
 def _accept_submission_suggestion(
-    cached_layer: CachedLayer, submission_suggestion: models.SubmissionSuggestion
+    cached_layer: CachedLayer,
+    submission_suggestion: models.SubmissionSuggestion,
+    background_tasks: BackgroundTasks,
 ) -> None:
     # Update the submission
     desc = None
@@ -100,11 +103,12 @@ def _accept_submission_suggestion(
             desc=desc,
             topic_uuids=submission_suggestion.topic_uuids,
         ),
+        background_tasks=background_tasks,
     )
     # Rebate the suggestion author
     from chafan_core.app.task import postprocess_accept_submission_suggestion
 
-    run_dramatiq_task(
+    background_tasks.add_task(
         postprocess_accept_submission_suggestion, submission_suggestion.id
     )
 
@@ -115,6 +119,7 @@ def update_submission_suggestions(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     update_in: SubmissionSuggestionUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     db = cached_layer.get_db()
     current_user_id = cached_layer.unwrapped_principal_id()
@@ -162,7 +167,7 @@ def update_submission_suggestions(
                     submission_suggestion.author
                 )
             db.commit()
-            _accept_submission_suggestion(cached_layer, submission_suggestion)
+            _accept_submission_suggestion(cached_layer, submission_suggestion, background_tasks=background_tasks)
         elif new_status == "rejected":
             _check_author(submission_suggestion, current_user_id)
             update_dict["rejected_at"] = utc_now

--- a/chafan_core/app/api/api_v1/endpoints/submissions.py
+++ b/chafan_core/app/api/api_v1/endpoints/submissions.py
@@ -31,7 +31,7 @@ router = APIRouter()
 # TODO: paging
 @router.get(
     "/",
-    response_model=Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]],
+    response_model=List[schemas.Submission],
 )
 def get_submissions_for_user(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer),
@@ -40,7 +40,7 @@ def get_submissions_for_user(
 
 
 @router.get(
-    "/{uuid}", response_model=Union[schemas.Submission, schemas.SubmissionForVisitor]
+    "/{uuid}", response_model=schemas.Submission
 )
 def get_submission(
     *,
@@ -58,7 +58,7 @@ def get_submission(
             detail="The submission doesn't exist in the system.",
         )
     submission_data: Optional[
-        Union[schemas.Submission, schemas.SubmissionForVisitor]
+        schemas.Submission
     ] = None
     # TODO didn't check principal id
     submission_data = cached_layer.submission_schema_from_orm(submission)

--- a/chafan_core/app/api/api_v1/endpoints/submissions.py
+++ b/chafan_core/app/api/api_v1/endpoints/submissions.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, List, Optional, Union
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 from chafan_core.app import crud, models, schemas, view_counters
 from chafan_core.app.api import deps
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import OperationType, client_ip, run_dramatiq_task
+from chafan_core.app.common import OperationType, client_ip
 from chafan_core.app.endpoint_utils import get_site
 from chafan_core.app.materialize import (
     check_user_in_site,
@@ -120,6 +120,7 @@ def _create_submission(
     cached_layer: CachedLayer,
     submission_in: schemas.SubmissionCreate,
     author: models.User,
+    background_tasks: BackgroundTasks,
 ) -> schemas.Submission:
     db = cached_layer.get_db()
     site = get_site(db, submission_in.site_uuid)
@@ -138,7 +139,7 @@ def _create_submission(
     new_submission = crud.submission.create_with_author(
         db, obj_in=submission_in, author_id=author.id
     )
-    run_dramatiq_task(postprocess_new_submission, new_submission.id)
+    background_tasks.add_task(postprocess_new_submission, new_submission.id)
     cached_layer.invalidate_submission_caches(new_submission)
     data = cached_layer.materializer.submission_schema_from_orm(new_submission)
     assert data is not None
@@ -151,6 +152,7 @@ def create_submission(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     *,
     submission_in: schemas.SubmissionCreate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Create new submission authored by the current user in one of the belonging sites.
@@ -163,7 +165,9 @@ def create_submission(
         api="post submission",
         request_info={"submission_in": jsonable_encoder(submission_in)},
     )
-    return _create_submission(cached_layer, submission_in, current_user)
+    return _create_submission(
+        cached_layer, submission_in, current_user, background_tasks=background_tasks
+    )
 
 
 def _update_submission(
@@ -171,6 +175,7 @@ def _update_submission(
     *,
     submission: models.Submission,
     submission_in: schemas.SubmissionUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Optional[schemas.Submission]:
     db = cached_layer.get_db()
     archive = models.SubmissionArchive(
@@ -209,7 +214,7 @@ def _update_submission(
     new_submission = crud.submission.update(
         db, db_obj=submission, obj_in=submission_in_dict
     )
-    run_dramatiq_task(postprocess_updated_submission, new_submission.id)
+    background_tasks.add_task(postprocess_updated_submission, new_submission.id)
     cached_layer.invalidate_submission_caches(new_submission)
     return cached_layer.materializer.submission_schema_from_orm(new_submission)
 
@@ -221,6 +226,7 @@ def update_submission(
     cached_layer: CachedLayer = Depends(deps.get_cached_layer_logged_in),
     uuid: str,
     submission_in: schemas.SubmissionUpdate,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Update submission as author.
@@ -248,6 +254,7 @@ def update_submission(
         cached_layer,
         submission=submission,
         submission_in=submission_in,
+        background_tasks=background_tasks,
     )
 
 

--- a/chafan_core/app/cached_layer.py
+++ b/chafan_core/app/cached_layer.py
@@ -215,14 +215,14 @@ class CachedLayer(object):
 
     def get_submissions_for_user(
         self,
-    ) -> Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]:
+    ) -> List[schemas.Submission]:
         return self._get_submissions_for_user(self.principal_id)
-        # def f() -> Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]:
+        # def f() -> List[schemas.Submission]:
         #     return self._get_submissions_for_user(self.principal_id)
         #
         # return self._get_cached(
         #     key=SUBMISSIONS_FOR_USER_CACHE_KEY.format(user_id=self.principal_id),
-        #     typeObj=Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]],
+        #     typeObj=List[schemas.Submission],
         #     fetch=f,
         #     hours=24,
         # )
@@ -251,7 +251,7 @@ class CachedLayer(object):
 
     def _get_submissions_for_user(
         self, current_user_id: Optional[int]
-    ) -> Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]:
+    ) -> List[schemas.Submission]:
         if current_user_id:
             current_user = crud.user.get(self.broker.get_db(), id=current_user_id)
             assert current_user is not None
@@ -272,18 +272,17 @@ class CachedLayer(object):
                     )
             return rank_submissions(submissions)
         else:
-            submissions_for_visitors: List[schemas.SubmissionForVisitor] = []
+            submissions: List[schemas.Submission] = []
             for site in crud.site.get_all_public_readable(self.broker.get_db()):
-                submissions_for_visitors.extend(
+                submissions.extend(
                     filter_not_none(
                         [
-                            self.materializer.submission_for_visitor_schema_from_orm(s)
+                            self.materializer.submission_schema_from_orm(s)
                             for s in site.submissions
                         ]
                     )[:10]
                 )
-            print(submissions_for_visitors)
-            return rank_submissions(submissions_for_visitors)
+            return rank_submissions(submissions)
 
     def get_site_by_subdomain(self, subdomain: str):
         return crud.site.get_by_subdomain(self.get_db(), subdomain=subdomain)
@@ -304,7 +303,7 @@ class CachedLayer(object):
 
     def get_site_submissions_for_user(
         self, *, site: models.Site, user_id: Optional[int], skip: int, limit: int
-    ) -> Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]:
+    ) -> List[schemas.Submission]:
         redis = self.get_redis()
         key = SITE_SUBMISSIONS_FOR_USER_CACHE_KEY.format(
             site_id=site.id, user_id=user_id
@@ -316,7 +315,7 @@ class CachedLayer(object):
                     skip : skip + limit
                 ]
             else:
-                return TypeAdapter(List[schemas.SubmissionForVisitor]).validate_json(
+                return TypeAdapter(List[schemas.Submission]).validate_json(
                     value
                 )[skip : skip + limit]
         submissions: List[Any] = []

--- a/chafan_core/app/cached_layer.py
+++ b/chafan_core/app/cached_layer.py
@@ -27,7 +27,7 @@ from chafan_core.app.data_broker import DataBroker
 from chafan_core.app.materialize import Materializer
 import chafan_core.app.responders as responders
 from chafan_core.app.recs.ranking import rank_site_profiles, rank_submissions
-from chafan_core.app.schemas.answer import AnswerPreview, AnswerPreviewForVisitor
+from chafan_core.app.schemas.answer import AnswerPreview
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.schemas.site import SiteCreate
 from chafan_core.utils.base import (
@@ -203,7 +203,7 @@ class CachedLayer(object):
         return answer_data
     def get_answer(
         self, uuid: str
-    ) -> Optional[Union[schemas.Answer, schemas.AnswerForVisitor]]:
+    ) -> Optional[schemas.Answer]:
         db = self.get_db()
         answer = crud.answer.get_by_uuid(db, uuid=uuid)
         if answer is None:
@@ -284,25 +284,6 @@ class CachedLayer(object):
                 )
             print(submissions_for_visitors)
             return rank_submissions(submissions_for_visitors)
-
-    def get_answer_for_visitor(self, uuid: str) -> Optional[schemas.AnswerForVisitor]:
-        redis_cli = self.get_redis()
-        key = ANSWER_FOR_VISITOR_CACHE_KEY.format(uuid=uuid)
-        value = redis_cli.get(key)
-        if value is not None:
-            return schemas.AnswerForVisitor.model_validate_json(value)
-        db = self.get_db()
-        answer = crud.answer.get_by_uuid(db, uuid=uuid)
-        if answer is None:
-            return None
-        if answer.visibility != ContentVisibility.ANYONE:
-            return None
-        answer_data = self.materializer.answer_for_visitor_schema_from_orm(answer)
-        if answer_data is None:
-            return None
-        if not is_dev():
-            redis_cli.set(key, answer_data.json(), ex=datetime.timedelta(hours=12))
-        return answer_data
 
     def get_site_by_subdomain(self, subdomain: str):
         return crud.site.get_by_subdomain(self.get_db(), subdomain=subdomain)
@@ -708,43 +689,28 @@ class CachedLayer(object):
 
     def preview_of_answer(
         self, answer: models.Answer
-    ) -> Union[Optional[AnswerPreview], Optional[AnswerPreviewForVisitor]]:
-        if self.principal_id:
-            return self.materializer.preview_of_answer(answer)
-        else:
-            return self.materializer.preview_of_answer_for_visitor(answer)
+    ) -> Optional[AnswerPreview]:
+        return self.materializer.preview_of_answer(answer)
 
     def get_authored_answers_for_principal(
         self, author: models.User
-    ) -> Union[List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]]:
+    ) -> List[schemas.AnswerPreview]:
         key = AUTHOR_ANSWERS_FOR_USER_CACHE_KEY.format(
             author_id=author.id, user_id=self.principal_id
         )
 
-        def f() -> (
-            Union[List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]]
-        ):
+        def f() -> List[schemas.AnswerPreview]:
             logger.info(f"not found in redis, fetch postgresql author={author.id}")
-            if self.principal_id:
-                return filter_not_none(
-                    [
-                        self.materializer.preview_of_answer(answer)
-                        for answer in author.answers
-                    ]
-                )
-            else:
-                return filter_not_none(
-                    [
-                        self.materializer.preview_of_answer_for_visitor(answer)
-                        for answer in author.answers
-                    ]
-                )
+            return filter_not_none(
+                [
+                    self.materializer.preview_of_answer(answer)
+                    for answer in author.answers
+                ]
+            )
 
         return self._get_cached_non_empty(
             key=key,
-            typeObj=Union[
-                List[schemas.AnswerPreview], List[schemas.AnswerPreviewForVisitor]
-            ],
+            typeObj=List[schemas.AnswerPreview],
             fallable_fetch=f,
             hours=24,
         )  # type: ignore

--- a/chafan_core/app/common.py
+++ b/chafan_core/app/common.py
@@ -64,13 +64,6 @@ def enable_rate_limit() -> bool:
     return not settings.DISABLE_RATE_LIMIT
 
 
-def run_dramatiq_task(task: Any, *arg: Any, **kwargs: Any) -> None:
-    # TODO This function should be moved out of common.py, to task.py
-    print("run_dramatiq_task")
-    print(arg)
-    #task(*arg, **kwargs)
-    task.send(*arg, **kwargs)
-
 
 def from_now(utc: datetime.datetime, locale: str) -> str:
     return arrow.get(utc).humanize(locale=locale)

--- a/chafan_core/app/config.py
+++ b/chafan_core/app/config.py
@@ -1,7 +1,6 @@
 from typing import Literal, Optional
 
 import sentry_sdk
-from sentry_sdk.integrations.dramatiq import DramatiqIntegration
 from pydantic import AnyHttpUrl
 from pydantic.types import SecretStr
 from pydantic_settings import BaseSettings
@@ -119,6 +118,5 @@ if settings.SENTRY_DSN:
         integrations=[
             RedisIntegration(),
             SqlalchemyIntegration(),
-            DramatiqIntegration(),
         ],
     )

--- a/chafan_core/app/materialize.py
+++ b/chafan_core/app/materialize.py
@@ -398,27 +398,12 @@ class Materializer(object):
             featured_at=answer.featured_at,
         )
 
-    def preview_of_answer_for_visitor(
-        self,
-        answer: models.Answer,
-    ) -> Optional[schemas.AnswerPreviewForVisitor]:
-        if not visitor_can_read_answer(answer=answer):
-            return None
-        question = self.preview_of_question(answer.question)
-        if not question:
-            return None
-        base = self.get_answer_preview_base(answer)
-        return schemas.AnswerPreviewForVisitor(
-            **base.dict(),
-            question=question,
-            full_answer=None,
-        )
-
     def preview_of_answer(
         self, answer: models.Answer
     ) -> Optional[schemas.AnswerPreview]:
-        if self.principal_id and not can_read_answer(
-            self.broker.get_db(), answer=answer, principal_id=self.principal_id
+        """One answer preview for any principal allowed to read the answer."""
+        if not user_permission.answer_read_allowed(
+            self.broker.get_db(), answer, self.principal_id
         ):
             return None
         question = self.preview_of_question(answer.question)
@@ -430,6 +415,13 @@ class Materializer(object):
             question=question,
             full_answer=None,
         )
+
+    # Back-compat alias during Step 1 migration of call sites.
+    def preview_of_answer_for_visitor(
+        self,
+        answer: models.Answer,
+    ) -> Optional[schemas.AnswerPreview]:
+        return self.preview_of_answer(answer)
 
     def preview_of_article(
         self, article: models.Article
@@ -755,89 +747,6 @@ class Materializer(object):
             )
             return None
 
-    def answer_for_visitor_schema_from_orm(
-        self,
-        answer: models.Answer,
-    ) -> Optional[schemas.AnswerForVisitor]:
-        if not visitor_can_read_answer(answer=answer):
-            return None
-        base = AnswerInDBBase.from_orm(answer)
-        d = base.dict()
-        d["site"] = self.site_schema_from_orm(answer.site)
-        d["comments"] = filter_not_none(
-            [self.comment_for_visitor_schema_from_orm(c) for c in answer.comments]
-        )
-        q = self.preview_of_question(answer.question)
-        if q is None:
-            return None
-        d["question"] = q
-        d["author"] = self.preview_of_user(answer.author)
-        d["view_times"] = 0 #view_counters.get_views(answer.uuid, "answer")
-        d["content"] = RichText(
-            source=answer.body,
-            rendered_text=answer.body_prerendered_text,
-            editor=answer.editor,
-        )
-        return schemas.AnswerForVisitor(**d)
-
-    def answer_schema_from_orm(self, answer: models.Answer) -> Optional[schemas.Answer]:
-        logger.error("TODO answer_schema_from_orm is deprecated in materialize")
-        if not self.principal_id:
-            return None
-        db = self.broker.get_db()
-        if not can_read_answer(db, answer=answer, principal_id=self.principal_id):
-            return None
-        upvoted = (
-            db.query(models.Answer_Upvotes)
-            .filter_by(answer_id=answer.id, voter_id=self.principal_id, cancelled=False)
-            .first()
-            is not None
-        )
-        comment_writable = user_in_site(
-            db,
-            site=answer.site,
-            user_id=self.principal_id,
-            op_type=OperationType.WriteSiteComment,
-        )
-        base = AnswerInDBBase.from_orm(answer)
-        d = base.dict()
-        d["site"] = self.site_schema_from_orm(answer.site)
-        d["comments"] = filter_not_none(
-            [self.comment_schema_from_orm(c) for c in answer.comments]
-        )
-        d["author"] = self.preview_of_user(answer.author)
-        d["question"] = self.preview_of_question(answer.question)
-        d["upvoted"] = upvoted
-        d["comment_writable"] = comment_writable
-        d["bookmark_count"] = answer.bookmarkers.count()
-        d["archives_count"] = len(answer.archives)
-        principal = crud.user.get(db, id=self.principal_id)
-        assert principal is not None
-        d["bookmarked"] = answer in principal.bookmarked_answers
-        d["view_times"] = 0 #view_counters.get_views(answer.uuid, "answer")
-        if answer.is_published:
-            body = answer.body
-        else:
-            if answer.body_draft:
-                body = answer.body_draft
-            else:
-                body = answer.body
-        d["content"] = RichText(
-            source=body,
-            rendered_text=answer.body_prerendered_text,
-            editor=answer.editor,
-        )
-        d["suggest_editable"] = answer.body_draft is None
-        return schemas.Answer(**d)
-
-    def get_materalized_answer(
-        self, answer: models.Answer
-    ) -> Union[Optional[schemas.Answer], Optional[schemas.AnswerForVisitor]]:
-        if self.principal_id is not None:
-            return self.answer_schema_from_orm(answer)
-        else:
-            return self.answer_for_visitor_schema_from_orm(answer)
-
     def submission_for_visitor_schema_from_orm(
         self,
         submission: models.Submission,
@@ -938,10 +847,15 @@ class Materializer(object):
         self,
         answer_suggest_edit: models.AnswerSuggestEdit,
     ) -> Optional[schemas.AnswerSuggestEdit]:
+        from chafan_core.app.cached_layer import CachedLayer
+
         base = schemas.AnswerSuggestEditInDB.from_orm(answer_suggest_edit)
         d = base.dict()
         d["author"] = self.preview_of_user(answer_suggest_edit.author)
-        answer = self.answer_schema_from_orm(answer_suggest_edit.answer)
+        # Full answer schema lives on responders (via CachedLayer).
+        answer = CachedLayer(self.broker, self.principal_id).answer_schema_from_orm(
+            answer_suggest_edit.answer
+        )
         if not answer:
             return None
         d["answer"] = answer

--- a/chafan_core/app/materialize.py
+++ b/chafan_core/app/materialize.py
@@ -19,7 +19,6 @@ from chafan_core.app.model_utils import (
 from chafan_core.app.schemas import event as event_module
 from chafan_core.app.schemas.answer import AnswerInDBBase
 from chafan_core.app.schemas.answer_archive import AnswerArchiveInDB
-from chafan_core.app.schemas.article import ArticleInDB
 from chafan_core.app.schemas.article_archive import ArticleArchiveInDB
 from chafan_core.app.schemas.event import (
     ClaimAnswerQuestionRewardInternal,
@@ -507,72 +506,6 @@ class Materializer(object):
         )
         return schemas.InvitationLink(**d)
 
-    def article_for_visitor_schema_from_orm(
-        self,
-        article: models.Article,
-    ) -> Optional[schemas.ArticleForVisitor]:
-        logger.error("TODO remove article_for_visitor_schema_from_orm from materialize")
-        if not visitor_can_read_article(article=article):
-            return None
-        base = ArticleInDB.from_orm(article)
-        d = base.dict()
-        d["article_column"] = self.article_column_schema_from_orm(
-            article.article_column
-        )
-        d["comments"] = filter_not_none(
-            [self.comment_for_visitor_schema_from_orm(c) for c in article.comments]
-        )
-        d["author"] = self.preview_of_user(article.author)
-        d["content"] = RichText(
-            source=article.body, editor=article.editor, rendered_text=article.body_text
-        )
-        return schemas.ArticleForVisitor(**d)
-
-    def article_schema_from_orm(
-        self, article: models.Article
-    ) -> Optional[schemas.Article]:
-        logger.error("TODO remove article_schema_from_orm from materialize")
-        if not self.principal_id:
-            return None
-        if not can_read_article(article=article, principal_id=self.principal_id):
-            return None
-        upvoted = (
-            self.broker.get_db()
-            .query(models.ArticleUpvotes)
-            .filter_by(
-                article_id=article.id, voter_id=self.principal_id, cancelled=False
-            )
-            .first()
-            is not None
-        )
-        base = ArticleInDB.from_orm(article)
-        d = base.dict()
-        d["article_column"] = self.article_column_schema_from_orm(
-            article.article_column
-        )
-        d["comments"] = filter_not_none(
-            [self.comment_schema_from_orm(c) for c in article.comments]
-        )
-        d["bookmark_count"] = article.bookmarkers.count()
-        principal = crud.user.get(self.broker.get_db(), id=self.principal_id)
-        assert principal is not None
-        d["bookmarked"] = article in principal.bookmarked_articles
-        d["author"] = self.preview_of_user(article.author)
-        d["upvoted"] = upvoted
-        d["view_times"] = 0#view_counters.get_views(article.uuid, "article")
-        d["archives_count"] = len(article.archives)
-        if article.is_published:
-            body = article.body
-        else:
-            if article.body_draft:
-                body = article.body_draft
-            else:
-                body = article.body
-        d["content"] = RichText(
-            source=body, editor=article.editor, rendered_text=article.body_text
-        )
-        return schemas.Article(**d)
-
     def reward_schema_from_orm(self, reward: models.Reward) -> schemas.Reward:
         base = schemas.RewardInDBBase.from_orm(reward)
         d = base.dict()
@@ -851,51 +784,31 @@ class Materializer(object):
             d["body_rich_text"] = None
         return schemas.AnswerSuggestEdit(**d)
 
-    def comment_for_visitor_schema_from_orm(
-        self,
-        comment: models.Comment,
-    ) -> Optional[schemas.CommentForVisitor]:
-        if comment.site and not comment.site.public_readable:
-            return None
-        base = schemas.CommentInDBBase.from_orm(comment)
-        d = base.dict()
-        d["root_route"] = root_route(comment)
-        d["author"] = self.preview_of_user(comment.author)
-        d["content"] = RichText(
-            source=comment.body,
-            rendered_text=comment.body_text,
-            editor=comment.editor,
-        )
-        d["child_comments"] = filter_not_none(
-            [
-                self.comment_for_visitor_schema_from_orm(c)
-                for c in comment.child_comments
-            ]
-        )
-        return schemas.CommentForVisitor(**d)
-
     # TODO: optimize -- principal can be unchecked if the parent (e.g. answer) is already checked with principal
     def comment_schema_from_orm(
         self, comment: models.Comment
     ) -> Optional[schemas.Comment]:
         db = self.broker.get_db()
-        if comment.site:
-            if self.principal_id and not user_in_site(
-                db,
-                site=comment.site,
-                user_id=self.principal_id,
-                op_type=OperationType.ReadSite,
-            ):
-                return None
+        if comment.site and not user_in_site(
+            db,
+            site=comment.site,
+            user_id=self.principal_id,
+            op_type=OperationType.ReadSite,
+        ):
+            return None
         base = schemas.CommentInDBBase.from_orm(comment)
-        upvoted = (
-            db.query(models.CommentUpvotes)
-            .filter_by(
-                comment_id=comment.id, voter_id=self.principal_id, cancelled=False
+        upvoted = False
+        if self.principal_id is not None:
+            upvoted = (
+                db.query(models.CommentUpvotes)
+                .filter_by(
+                    comment_id=comment.id,
+                    voter_id=self.principal_id,
+                    cancelled=False,
+                )
+                .first()
+                is not None
             )
-            .first()
-            is not None
-        )
         d = base.dict()
         d["author"] = self.preview_of_user(comment.author)
         d["upvoted"] = upvoted

--- a/chafan_core/app/materialize.py
+++ b/chafan_core/app/materialize.py
@@ -28,10 +28,7 @@ from chafan_core.app.schemas.event import (
     EventInternal,
 )
 from chafan_core.app.schemas.notification import Notification, NotificationInDBBase
-from chafan_core.app.schemas.question import (
-        QuestionInDBBase,
-        QuestionPreviewForSearch
-)
+from chafan_core.app.schemas.question import QuestionPreviewForSearch
 from chafan_core.app.schemas.reward import AnsweredQuestionCondition, RewardCondition
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.security import IntlPhoneNumber
@@ -85,7 +82,7 @@ def user_in_site(
     db: Session,
     *,
     site: models.Site,
-    user_id: int,
+    user_id: Optional[int],
     op_type: OperationType,
 ) -> bool:
     # TODO remove it from materialize
@@ -344,9 +341,21 @@ class Materializer(object):
         )
         return schemas.ArticleColumn(**data_dict)
 
-    def get_question_preview_for_visitor(
+    def preview_of_question(
         self, question: models.Question
-    ) -> schemas.QuestionPreviewForVisitor:
+    ) -> Optional[schemas.QuestionPreview]:
+        """One question preview for any principal allowed to read the site."""
+        if not user_in_site(
+            self.broker.get_db(),
+            site=question.site,
+            user_id=self.principal_id,
+            op_type=OperationType.ReadSite,
+        ):
+            return None
+        if question.is_hidden and (
+            self.principal_id is None or self.principal_id != question.author_id
+        ):
+            return None
         desc = None
         if question.description:
             desc = RichText(
@@ -354,7 +363,7 @@ class Materializer(object):
                 editor=question.description_editor,
                 rendered_text=question.description_text,
             )
-        return schemas.QuestionPreviewForVisitor(
+        return schemas.QuestionPreview(
             uuid=question.uuid,
             title=question.title,
             author=self.preview_of_user(question.author),
@@ -363,35 +372,17 @@ class Materializer(object):
             desc=desc,
             answers_count=len(get_live_answers_of_question(question)),
             upvotes=self.get_question_upvotes(question),
-        )
-
-    def preview_of_question_for_visitor(
-        self,
-        question: models.Question,
-    ) -> Optional[schemas.QuestionPreviewForVisitor]:
-        if not question.site.public_readable:
-            return None
-        if not is_eligible_item(question, _VISIBLE_QUESTION_CONDITIONS):
-            return None
-        return self.get_question_preview_for_visitor(question)
-
-    def preview_of_question(
-        self, question: models.Question
-    ) -> Optional[schemas.QuestionPreview]:
-        if self.principal_id and not user_in_site(
-            self.broker.get_db(),
-            site=question.site,
-            user_id=self.principal_id,
-            op_type=OperationType.ReadSite,
-        ):
-            return None
-        preview_base = self.get_question_preview_for_visitor(question)
-        return schemas.QuestionPreview(
-            **preview_base.dict(),
             site=self.site_schema_from_orm(question.site),
             upvotes_count=question.upvotes_count,
             comments_count=len(question.comments),
         )
+
+    # Back-compat alias during Step 1 migration of call sites.
+    def preview_of_question_for_visitor(
+        self,
+        question: models.Question,
+    ) -> Optional[schemas.QuestionPreview]:
+        return self.preview_of_question(question)
 
     def get_answer_preview_base(
         self, answer: models.Answer
@@ -413,7 +404,7 @@ class Materializer(object):
     ) -> Optional[schemas.AnswerPreviewForVisitor]:
         if not visitor_can_read_answer(answer=answer):
             return None
-        question = self.preview_of_question_for_visitor(answer.question)
+        question = self.preview_of_question(answer.question)
         if not question:
             return None
         base = self.get_answer_preview_base(answer)
@@ -776,7 +767,7 @@ class Materializer(object):
         d["comments"] = filter_not_none(
             [self.comment_for_visitor_schema_from_orm(c) for c in answer.comments]
         )
-        q = self.preview_of_question_for_visitor(answer.question)
+        q = self.preview_of_question(answer.question)
         if q is None:
             return None
         d["question"] = q
@@ -839,48 +830,6 @@ class Materializer(object):
         d["suggest_editable"] = answer.body_draft is None
         return schemas.Answer(**d)
 
-    def question_schema_from_orm(
-        self, question: models.Question
-    ) -> Optional[schemas.Question]:
-        logger.error("materialize question_data is deprecated")
-        if not self.principal_id:
-            return None
-        if not user_in_site(
-            self.broker.get_db(),
-            site=question.site,
-            user_id=self.principal_id,
-            op_type=OperationType.ReadSite,
-        ):
-            return None
-        upvoted = (
-            self.broker.get_db()
-            .query(models.QuestionUpvotes)
-            .filter_by(
-                question_id=question.id, voter_id=self.principal_id, cancelled=False
-            )
-            .first()
-            is not None
-        )
-        base = QuestionInDBBase.from_orm(question)
-        d = base.dict()
-        d["site"] = self.site_schema_from_orm(question.site)
-        d["comments"] = filter_not_none(
-            [self.comment_schema_from_orm(c) for c in question.comments]
-        )
-        d["author"] = self.preview_of_user(question.author)
-        d["editor"] = map_(question.editor, self.preview_of_user)
-        d["upvoted"] = upvoted
-        d["view_times"] = 0 #view_counters.get_views(question.uuid, "question")
-        d["answers_count"] = len(get_live_answers_of_question(question))
-        if question.description is not None:
-            d["desc"] = RichText(
-                source=question.description,
-                editor=question.description_editor,
-                rendered_text=question.description_text,
-            )
-        d["upvotes"] = self.get_question_upvotes(question)
-        return schemas.Question(**d)
-
     def get_materalized_answer(
         self, answer: models.Answer
     ) -> Union[Optional[schemas.Answer], Optional[schemas.AnswerForVisitor]]:
@@ -888,29 +837,6 @@ class Materializer(object):
             return self.answer_schema_from_orm(answer)
         else:
             return self.answer_for_visitor_schema_from_orm(answer)
-
-    def question_for_visitor_schema_from_orm(
-        self,
-        question: models.Question,
-    ) -> Optional[schemas.QuestionForVisitor]:
-        if not question.site.public_readable:
-            return None
-        base = QuestionInDBBase.from_orm(question)
-        d = base.dict()
-        d["author"] = self.preview_of_user(question.author)
-        d["site"] = self.site_schema_from_orm(question.site)
-        d["comments"] = filter_not_none(
-            [self.comment_for_visitor_schema_from_orm(c) for c in question.comments]
-        )
-        d["answers_count"] = len(get_live_answers_of_question(question))
-        if question.description:
-            d["desc"] = RichText(
-                source=question.description,
-                editor=question.description_editor,
-                rendered_text=question.description_text,
-            )
-        d["upvotes"] = self.get_question_upvotes(question)
-        return schemas.QuestionForVisitor(**d)
 
     def submission_for_visitor_schema_from_orm(
         self,

--- a/chafan_core/app/materialize.py
+++ b/chafan_core/app/materialize.py
@@ -747,36 +747,10 @@ class Materializer(object):
             )
             return None
 
-    def submission_for_visitor_schema_from_orm(
-        self,
-        submission: models.Submission,
-    ) -> Optional[schemas.SubmissionForVisitor]:
-        if not submission.site.public_readable:
-            return None
-        if submission.is_hidden:
-            return None
-        base = schemas.SubmissionInDB.from_orm(submission)
-        d = base.dict()
-        d["site"] = self.site_schema_from_orm(submission.site)
-        d["comments"] = filter_not_none(
-            [self.comment_for_visitor_schema_from_orm(c) for c in submission.comments]
-        )
-        d["author"] = self.preview_of_user(submission.author)
-        d["contributors"] = [self.preview_of_user(u) for u in submission.contributors]
-        if submission.description:
-            d["desc"] = RichText(
-                source=submission.description,
-                rendered_text=submission.description_text,
-                editor=submission.description_editor,
-            )
-        return schemas.SubmissionForVisitor(**d)
-
     def submission_schema_from_orm(
         self, submission: models.Submission
     ) -> Optional[schemas.Submission]:
-        #logger.error("TODO submission_schema_from_orm in materialize.py is deprecated")
-        # 2025-Sep-14 This log it too noisy
-        if self.principal_id and not user_in_site(
+        if not user_in_site(
             self.broker.get_db(),
             site=submission.site,
             user_id=self.principal_id,
@@ -793,7 +767,7 @@ class Materializer(object):
         )
         d["author"] = self.preview_of_user(submission.author)
         d["contributors"] = [self.preview_of_user(u) for u in submission.contributors]
-        d["view_times"] = 0 #view_counters.get_views(submission.uuid, "submission")
+        d["view_times"] = 0  # view_counters.get_views(submission.uuid, "submission")
         if submission.description is not None:
             d["desc"] = RichText(
                 source=submission.description,
@@ -801,6 +775,13 @@ class Materializer(object):
                 editor=submission.description_editor,
             )
         return schemas.Submission(**d)
+
+    # Back-compat alias during Step 1 migration of call sites.
+    def submission_for_visitor_schema_from_orm(
+        self,
+        submission: models.Submission,
+    ) -> Optional[schemas.Submission]:
+        return self.submission_schema_from_orm(submission)
 
     def notification_schema_from_orm(
         self, notification: models.Notification

--- a/chafan_core/app/recs/indexed_layer.py
+++ b/chafan_core/app/recs/indexed_layer.py
@@ -40,29 +40,20 @@ def _get_interesting_question_ids(user: models.User) -> List[int]:
 
 def get_interesting_questions(
     cached_layer: CachedLayer,
-) -> Union[List[schemas.QuestionPreview], List[schemas.QuestionPreviewForVisitor]]:
+) -> List[schemas.QuestionPreview]:
     current_user = cached_layer.try_get_current_user()
     if not current_user:
-        visitor = crud.user.try_get_visitor_user(cached_layer.get_db())
-        if not visitor:
+        current_user = crud.user.try_get_visitor_user(cached_layer.get_db())
+        if not current_user:
             return []
-        return filter_not_none(
-            [
-                cached_layer.materializer.preview_of_question_for_visitor(
-                    unwrap(crud.question.get(cached_layer.get_db(), id=q_id))
-                )
-                for q_id in _get_interesting_question_ids(visitor)
-            ]
-        )
-    else:
-        return filter_not_none(
-            [
-                cached_layer.materializer.preview_of_question(
-                    unwrap(crud.question.get(cached_layer.get_db(), id=q_id))
-                )
-                for q_id in _get_interesting_question_ids(current_user)
-            ]
-        )
+    return filter_not_none(
+        [
+            cached_layer.materializer.preview_of_question(
+                unwrap(crud.question.get(cached_layer.get_db(), id=q_id))
+            )
+            for q_id in _get_interesting_question_ids(current_user)
+        ]
+    )
 
 
 def _get_interesting_user_ids(user: models.User) -> List[int]:

--- a/chafan_core/app/recs/indexed_layer.py
+++ b/chafan_core/app/recs/indexed_layer.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Union
 
 from chafan_core.app import crud, models, schemas
 from chafan_core.app.cached_layer import CachedLayer
-from chafan_core.app.common import run_dramatiq_task
 from chafan_core.app.data_broker import DataBroker
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.task import (
@@ -30,7 +29,7 @@ def _get_interesting_question_ids(user: models.User) -> List[int]:
         refresh_interesting_question_ids_for_user(user.id)
     # if a bit old, enqueue refresh task
     elif _is_expired(user.interesting_question_ids_updated_at, days_in_seconds(3)):
-        run_dramatiq_task(refresh_interesting_question_ids_for_user, user.id)
+        refresh_interesting_question_ids_for_user(user.id)
 
     # return latest version
     if user.interesting_question_ids is None:
@@ -62,7 +61,7 @@ def _get_interesting_user_ids(user: models.User) -> List[int]:
         refresh_interesting_user_ids_for_user(user.id)
     # if a bit old, enqueue refresh task
     elif _is_expired(user.interesting_user_ids_updated_at, days_in_seconds(3)):
-        run_dramatiq_task(refresh_interesting_user_ids_for_user, user.id)
+        refresh_interesting_user_ids_for_user(user.id)
 
     # return latest version
     if user.interesting_user_ids is None:

--- a/chafan_core/app/recs/ranking.py
+++ b/chafan_core/app/recs/ranking.py
@@ -33,12 +33,12 @@ def freshness(
 
 
 def rank_submissions(
-    submissions: Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]
-) -> Union[List[schemas.Submission], List[schemas.SubmissionForVisitor]]:
+    submissions: List[schemas.Submission]
+) -> List[schemas.Submission]:
     utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     def hotness(
-        submission: Union[schemas.Submission, schemas.SubmissionForVisitor]
+        submission: schemas.Submission
     ) -> float:
         return float(submission.upvotes_count + 1) * freshness(
             utc_now, submission.updated_at, recency_boost=1

--- a/chafan_core/app/responders/answer.py
+++ b/chafan_core/app/responders/answer.py
@@ -1,36 +1,42 @@
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
-
-from chafan_core.app import models, schemas
-from chafan_core.app.schemas.richtext import RichText
-from chafan_core.utils.base import (
-    filter_not_none,
-)
-
-from chafan_core.app import view_counters
-
-
-from chafan_core.app.schemas.answer import AnswerInDBBase
-
+from typing import Optional
 import logging
+
+from chafan_core.app import crud, models, schemas, user_permission, view_counters
+from chafan_core.app.common import OperationType
+from chafan_core.app.schemas.answer import AnswerInDBBase
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.utils.base import filter_not_none
+
 logger = logging.getLogger(__name__)
 
-def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) -> Optional[schemas.Answer]:
+
+def answer_schema_from_orm(
+    cached_layer, answer: models.Answer, principal_id
+) -> Optional[schemas.Answer]:
     db = cached_layer.broker.get_db()
-    #if not can_read_answer(db, answer=answer, principal_id=self.principal_id):
-    #    return None
-    upvoted = (
-        db.query(models.Answer_Upvotes)
-        .filter_by(answer_id=answer.id, voter_id=principal_id, cancelled=False)
-        .first()
-        is not None
-    )
-    # TODO skipped the permission check
-#    comment_writable = user_in_site(
-#        db,
-#        site=answer.site,
-#        user_id=self.principal_id,
-#        op_type=OperationType.WriteSiteComment,
-#    )
+    if not user_permission.answer_read_allowed(db, answer=answer, user_id=principal_id):
+        return None
+
+    upvoted = False
+    comment_writable = False
+    bookmarked = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.Answer_Upvotes)
+            .filter_by(answer_id=answer.id, voter_id=principal_id, cancelled=False)
+            .first()
+            is not None
+        )
+        comment_writable = user_permission.user_in_site(
+            db,
+            site=answer.site,
+            user_id=principal_id,
+            op_type=OperationType.WriteSiteComment,
+        )
+        principal = crud.user.get(db, id=principal_id)
+        if principal is not None:
+            bookmarked = answer in principal.bookmarked_answers
+
     base = AnswerInDBBase.from_orm(answer)
     d = base.dict()
     d["site"] = cached_layer.site_schema_from_orm(answer.site)
@@ -40,21 +46,20 @@ def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) ->
     d["author"] = cached_layer.materializer.preview_of_user(answer.author)
     d["question"] = cached_layer.materializer.preview_of_question(answer.question)
     d["upvoted"] = upvoted
-    d["comment_writable"] = True #comment_writable
+    d["comment_writable"] = comment_writable
     d["bookmark_count"] = answer.bookmarkers.count()
     d["archives_count"] = len(answer.archives)
-    #principal = crud.user.get(db, id=principal_id)
-    #assert principal is not None
-    d["bookmarked"] = True #answer in principal.bookmarked_answers
+    d["bookmarked"] = bookmarked
     d["view_times"] = view_counters.get_viewcount_answer(cached_layer.broker, answer.id)
+
     if answer.is_published:
         body = answer.body
     else:
-        logger.error("FIXME draft read permission not checked")
-        if answer.body_draft:
-            body = answer.body_draft
-        else:
-            body = answer.body
+        # Unpublished drafts: only the author may read (enforced above); serve draft body.
+        if principal_id != answer.author_id:
+            return None
+        body = answer.body_draft if answer.body_draft else answer.body
+
     d["content"] = RichText(
         source=body,
         rendered_text=answer.body_prerendered_text,
@@ -62,4 +67,3 @@ def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) ->
     )
     d["suggest_editable"] = answer.body_draft is None
     return schemas.Answer(**d)
-

--- a/chafan_core/app/responders/article.py
+++ b/chafan_core/app/responders/article.py
@@ -1,33 +1,34 @@
 from typing import Optional
 import logging
-logger = logging.getLogger(__name__)
 
-from chafan_core.app import crud, models, schemas
-from chafan_core.app.schemas.richtext import RichText
-from chafan_core.utils.base import (
-    filter_not_none,
-)
-
+from chafan_core.app import crud, models, schemas, user_permission, view_counters
 from chafan_core.app.schemas.article import ArticleInDB
-from chafan_core.app.schemas.article_archive import ArticleArchiveInDB
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.utils.base import filter_not_none
 
-
-from chafan_core.app import view_counters
+logger = logging.getLogger(__name__)
 
 
 def article_schema_from_orm(
     cached_layer, article: models.Article, principal_id
 ) -> Optional[schemas.Article]:
-    # TODO need to check if the user is allowed to read this article
-    upvoted = (
-        cached_layer.broker.get_db()
-        .query(models.ArticleUpvotes)
-        .filter_by(
-            article_id=article.id, voter_id=principal_id, cancelled=False
+    db = cached_layer.broker.get_db()
+    if not user_permission.article_read_allowed(db, article, principal_id):
+        return None
+
+    upvoted = False
+    bookmarked = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.ArticleUpvotes)
+            .filter_by(article_id=article.id, voter_id=principal_id, cancelled=False)
+            .first()
+            is not None
         )
-        .first()
-        is not None
-    )
+        principal = crud.user.get(db, id=principal_id)
+        if principal is not None:
+            bookmarked = article in principal.bookmarked_articles
+
     base = ArticleInDB.from_orm(article)
     d = base.dict()
     d["article_column"] = cached_layer.materializer.article_column_schema_from_orm(
@@ -37,21 +38,22 @@ def article_schema_from_orm(
         [cached_layer.materializer.comment_schema_from_orm(c) for c in article.comments]
     )
     d["bookmark_count"] = article.bookmarkers.count()
-    principal = crud.user.get(cached_layer.broker.get_db(), id=principal_id)
-    #assert principal is not None
-    #d["bookmarked"] = article in principal.bookmarked_articles
-    d["bookmarked"] = True # TODO leave it for now 2025-07-24
+    d["bookmarked"] = bookmarked
     d["author"] = cached_layer.materializer.preview_of_user(article.author)
     d["upvoted"] = upvoted
-    d["view_times"] = view_counters.get_viewcount_article(cached_layer.broker, article.id)
+    d["view_times"] = view_counters.get_viewcount_article(
+        cached_layer.broker, article.id
+    )
     d["archives_count"] = len(article.archives)
+
     if article.is_published:
         body = article.body
     else:
-        if article.body_draft:
-            body = article.body_draft
-        else:
-            body = article.body
+        # Drafts: only the author may read (enforced by article_read_allowed).
+        if principal_id != article.author_id:
+            return None
+        body = article.body_draft if article.body_draft else article.body
+
     d["content"] = RichText(
         source=body, editor=article.editor, rendered_text=article.body_text
     )

--- a/chafan_core/app/responders/question.py
+++ b/chafan_core/app/responders/question.py
@@ -7,16 +7,76 @@ import chafan_core.app.responders as responders
 from chafan_core.app import models, schemas
 from chafan_core.app.common import OperationType
 from chafan_core.app.data_broker import DataBroker
-from chafan_core.app.model_utils import (
-    get_live_answers_of_question,
-)
+from chafan_core.app.model_utils import get_live_answers_of_question
 from chafan_core.app.schemas.question import QuestionInDBBase
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app import user_permission, view_counters
-from chafan_core.utils.base import (
-    filter_not_none,
-    map_,
-)
+from chafan_core.utils.base import filter_not_none, map_
+
+
+def get_question_upvotes(
+    db, question: models.Question, principal_id
+) -> schemas.QuestionUpvotes:
+    valid_upvotes = (
+        db.query(models.QuestionUpvotes)
+        .filter_by(question_id=question.id, cancelled=False)
+        .count()
+    )
+    upvoted = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.QuestionUpvotes)
+            .filter_by(
+                question_id=question.id,
+                voter_id=principal_id,
+                cancelled=False,
+            )
+            .first()
+            is not None
+        )
+    return schemas.QuestionUpvotes(
+        question_uuid=question.uuid, count=valid_upvotes, upvoted=upvoted
+    )
+
+
+def preview_of_question(
+    cached_layer, question: models.Question
+) -> Optional[schemas.QuestionPreview]:
+    """One question preview schema for any principal allowed to read the site."""
+    db = cached_layer.get_db()
+    principal_id = cached_layer.principal_id
+    if not user_permission.user_in_site(
+        db,
+        site=question.site,
+        user_id=principal_id,
+        op_type=OperationType.ReadSite,
+    ):
+        return None
+    if question.is_hidden and (
+        principal_id is None or principal_id != question.author_id
+    ):
+        return None
+
+    desc = None
+    if question.description:
+        desc = RichText(
+            source=question.description,
+            editor=question.description_editor,
+            rendered_text=question.description_text,
+        )
+    return schemas.QuestionPreview(
+        uuid=question.uuid,
+        title=question.title,
+        author=cached_layer.preview_of_user(question.author),
+        is_placed_at_home=question.is_placed_at_home,
+        created_at=question.created_at,
+        desc=desc,
+        answers_count=len(get_live_answers_of_question(question)),
+        upvotes=get_question_upvotes(db, question, principal_id),
+        site=responders.site.site_schema_from_orm(cached_layer, question.site),
+        upvotes_count=question.upvotes_count,
+        comments_count=len(question.comments),
+    )
 
 
 def question_schema_from_orm(
@@ -61,5 +121,5 @@ def question_schema_from_orm(
             editor=question.description_editor,
             rendered_text=question.description_text,
         )
-    d["upvotes"] = cached_layer.materializer.get_question_upvotes(question)
+    d["upvotes"] = get_question_upvotes(db, question, principal_id)
     return schemas.Question(**d)

--- a/chafan_core/app/responders/question.py
+++ b/chafan_core/app/responders/question.py
@@ -1,66 +1,49 @@
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Optional
 import logging
-logger = logging.getLogger(__name__)
 
-from sqlalchemy.orm import Session
+logger = logging.getLogger(__name__)
 
 import chafan_core.app.responders as responders
 from chafan_core.app import models, schemas
-from chafan_core.app.common import OperationType, is_dev
+from chafan_core.app.common import OperationType
 from chafan_core.app.data_broker import DataBroker
 from chafan_core.app.model_utils import (
     get_live_answers_of_question,
 )
-from chafan_core.app.schemas.question import (
-        QuestionInDBBase,
-        QuestionPreviewForSearch
-)
+from chafan_core.app.schemas.question import QuestionInDBBase
 from chafan_core.app.schemas.richtext import RichText
+from chafan_core.app import user_permission, view_counters
 from chafan_core.utils.base import (
     filter_not_none,
     map_,
-    unwrap,
 )
-
-from chafan_core.app import view_counters
-
-def user_in_site(
-    db: Session,
-    *,
-    site: models.Site,
-    user_id: int,
-    op_type: OperationType,
-) -> bool:
-    logger.error("user_in_site is stub TODO")
-    return True
 
 
 def question_schema_from_orm(
-        broker: DataBroker,
-        principal_id,
-        question: models.Question,
-        cached_layer # TODO we should remove this dependency in future 2025-07-23
+    broker: DataBroker,
+    principal_id,
+    question: models.Question,
+    cached_layer,  # TODO we should remove this dependency in future 2025-07-23
 ) -> Optional[schemas.Question]:
-    if not principal_id:
-        logger.error("TODO skipped principle_id check")
-        #return None
-    if not user_in_site(
-        broker.get_db(),
+    db = broker.get_db()
+    if not user_permission.user_in_site(
+        db,
         site=question.site,
         user_id=principal_id,
         op_type=OperationType.ReadSite,
     ):
-        logger.error("TODO skipped principle_id check")
+        return None
 
-    upvoted = (
-        broker.get_db()
-        .query(models.QuestionUpvotes)
-        .filter_by(
-            question_id=question.id, voter_id=principal_id, cancelled=False
+    upvoted = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.QuestionUpvotes)
+            .filter_by(
+                question_id=question.id, voter_id=principal_id, cancelled=False
+            )
+            .first()
+            is not None
         )
-        .first()
-        is not None
-    )
     base = QuestionInDBBase.from_orm(question)
     d = base.dict()
     d["site"] = responders.site.site_schema_from_orm(cached_layer, question.site)

--- a/chafan_core/app/responders/submission.py
+++ b/chafan_core/app/responders/submission.py
@@ -1,16 +1,14 @@
 from typing import Optional
-
-from chafan_core.app import models, schemas
-from chafan_core.app.schemas.richtext import RichText
-from chafan_core.utils.base import (
-    filter_not_none,
-)
+import logging
 
 import chafan_core.app.responders as responders
-from chafan_core.app import view_counters
+from chafan_core.app import models, schemas, user_permission, view_counters
+from chafan_core.app.common import OperationType
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.utils.base import filter_not_none
 
-import logging
 logger = logging.getLogger(__name__)
+
 
 def submission_schema_from_orm(
     cached_layer,
@@ -18,15 +16,29 @@ def submission_schema_from_orm(
 ) -> Optional[schemas.Submission]:
     if submission.is_hidden:
         return None
+    if not user_permission.user_in_site(
+        cached_layer.get_db(),
+        site=submission.site,
+        user_id=cached_layer.principal_id,
+        op_type=OperationType.ReadSite,
+    ):
+        return None
     base = schemas.SubmissionInDB.from_orm(submission)
     d = base.dict()
     d["site"] = responders.site.site_schema_from_orm(cached_layer, submission.site)
     d["comments"] = filter_not_none(
-        [cached_layer.materializer.comment_schema_from_orm(c) for c in submission.comments]
+        [
+            cached_layer.materializer.comment_schema_from_orm(c)
+            for c in submission.comments
+        ]
     )
     d["author"] = cached_layer.preview_of_user(submission.author)
-    d["contributors"] = [cached_layer.preview_of_user(u) for u in submission.contributors]
-    d["view_times"] = view_counters.get_viewcount_submission(cached_layer.broker, submission.id)
+    d["contributors"] = [
+        cached_layer.preview_of_user(u) for u in submission.contributors
+    ]
+    d["view_times"] = view_counters.get_viewcount_submission(
+        cached_layer.broker, submission.id
+    )
     if submission.description is not None:
         d["desc"] = RichText(
             source=submission.description,

--- a/chafan_core/app/schemas/__init__.py
+++ b/chafan_core/app/schemas/__init__.py
@@ -15,10 +15,8 @@ from .activity import (
 from .answer import (
     Answer,
     AnswerCreate,
-    AnswerForVisitor,
     AnswerInDBBase,
     AnswerPreview,
-    AnswerPreviewForVisitor,
     AnswerUpdate,
     AnswerUpvotes,
 )

--- a/chafan_core/app/schemas/__init__.py
+++ b/chafan_core/app/schemas/__init__.py
@@ -33,7 +33,6 @@ from .article import (
     ArticleColumn,
     ArticleCreate,
     ArticleDraft,
-    ArticleForVisitor,
     ArticlePreview,
     ArticleTopicsUpdate,
     ArticleUpdate,
@@ -58,7 +57,6 @@ from .coin_payment import (
 from .comment import (
     Comment,
     CommentCreate,
-    CommentForVisitor,
     CommentInDBBase,
     CommentUpdate,
     CommentUpvotes,
@@ -134,7 +132,6 @@ from .user import (
     UserInDBBase,
     UserInvite,
     UserPublic,
-    UserPublicForVisitor,
     UserQuestionSubscription,
     UserSubmissionSubscription,
     UserTopicSubscription,

--- a/chafan_core/app/schemas/__init__.py
+++ b/chafan_core/app/schemas/__init__.py
@@ -90,10 +90,8 @@ from .profile import Profile, ProfileCreate, ProfileInDB, ProfileInDBBase, Profi
 from .question import (
     Question,
     QuestionCreate,
-    QuestionForVisitor,
     QuestionInDB,
     QuestionPreview,
-    QuestionPreviewForVisitor,
     QuestionPreviewForSearch,
     QuestionUpdate,
     QuestionUpvotes,

--- a/chafan_core/app/schemas/__init__.py
+++ b/chafan_core/app/schemas/__init__.py
@@ -103,7 +103,6 @@ from .site import Site, SiteCreate, SiteInDB, SiteInDBBase, SiteUpdate
 from .submission import (
     Submission,
     SubmissionCreate,
-    SubmissionForVisitor,
     SubmissionInDB,
     SubmissionUpdate,
     SubmissionUpvotes,

--- a/chafan_core/app/schemas/answer.py
+++ b/chafan_core/app/schemas/answer.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from chafan_core.app.schemas.comment import Comment, CommentForVisitor
+from chafan_core.app.schemas.comment import Comment
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.schemas.question import QuestionPreview
 from chafan_core.app.schemas.richtext import RichText
@@ -58,7 +58,7 @@ class AnswerUpvotes(BaseModel):
     upvoted: bool
 
 
-# Additional properties to return via API
+# One schema for any principal allowed to read the answer
 class Answer(AnswerInDBBase):
     content: RichText
     comments: List[Comment] = []
@@ -70,17 +70,6 @@ class Answer(AnswerInDBBase):
     bookmarked: bool
     view_times: int
     archives_count: int
-    upvotes: Optional[AnswerUpvotes] = None
-    suggest_editable: bool = False
-
-
-class AnswerForVisitor(AnswerInDBBase):
-    content: RichText
-    author: UserPreview
-    site: Site
-    view_times: int
-    comments: List[CommentForVisitor] = []
-    question: QuestionPreview
     upvotes: Optional[AnswerUpvotes] = None
     suggest_editable: bool = False
 
@@ -102,9 +91,4 @@ class AnswerPreviewBase(BaseModel):
 
 class AnswerPreview(AnswerPreviewBase):
     question: QuestionPreview
-    full_answer: Optional[Answer]
-
-
-class AnswerPreviewForVisitor(AnswerPreviewBase):
-    question: QuestionPreview
-    full_answer: Optional[AnswerForVisitor]
+    full_answer: Optional[Answer] = None

--- a/chafan_core/app/schemas/answer.py
+++ b/chafan_core/app/schemas/answer.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from chafan_core.app.schemas.comment import Comment, CommentForVisitor
 from chafan_core.app.schemas.preview import UserPreview
-from chafan_core.app.schemas.question import QuestionPreview, QuestionPreviewForVisitor
+from chafan_core.app.schemas.question import QuestionPreview
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.site import Site
 from chafan_core.utils.base import ContentVisibility
@@ -80,7 +80,7 @@ class AnswerForVisitor(AnswerInDBBase):
     site: Site
     view_times: int
     comments: List[CommentForVisitor] = []
-    question: QuestionPreviewForVisitor
+    question: QuestionPreview
     upvotes: Optional[AnswerUpvotes] = None
     suggest_editable: bool = False
 
@@ -106,5 +106,5 @@ class AnswerPreview(AnswerPreviewBase):
 
 
 class AnswerPreviewForVisitor(AnswerPreviewBase):
-    question: QuestionPreviewForVisitor
+    question: QuestionPreview
     full_answer: Optional[AnswerForVisitor]

--- a/chafan_core/app/schemas/article.py
+++ b/chafan_core/app/schemas/article.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import BaseModel, validator
 
 from chafan_core.app.schemas.article_column import ArticleColumn
-from chafan_core.app.schemas.comment import Comment, CommentForVisitor
+from chafan_core.app.schemas.comment import Comment
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.topic import Topic
@@ -82,14 +82,6 @@ class Article(ArticleInDBBase):
     bookmarked: bool
     archives_count: int
 
-
-# Additional properties to return via API
-class ArticleForVisitor(ArticleInDBBase):
-    content: RichText
-
-    author: UserPreview
-    comments: List[CommentForVisitor]
-    article_column: ArticleColumn
 
 
 # Additional properties stored in DB

--- a/chafan_core/app/schemas/comment.py
+++ b/chafan_core/app/schemas/comment.py
@@ -55,10 +55,3 @@ class CommentUpvotes(BaseModel):
     comment_uuid: str
     count: int
     upvoted: bool
-
-
-class CommentForVisitor(CommentInDBBase):
-    content: RichText
-    author: UserPreview
-    root_route: Optional[str] = None
-    child_comments: List["CommentForVisitor"] = []

--- a/chafan_core/app/schemas/question.py
+++ b/chafan_core/app/schemas/question.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, validator
 
-from chafan_core.app.schemas.comment import Comment, CommentForVisitor
+from chafan_core.app.schemas.comment import Comment
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.site import Site
@@ -61,7 +61,7 @@ class QuestionUpvotes(BaseModel):
     upvoted: bool
 
 
-# Additional properties to return via API
+# Additional properties to return via API (one schema for all allowed readers)
 class Question(QuestionInDBBase):
     desc: Optional[RichText] = None
     author: UserPreview
@@ -71,15 +71,7 @@ class Question(QuestionInDBBase):
     answers_count: int
     view_times: int
     upvotes: Optional[QuestionUpvotes] = None
-
-
-class QuestionForVisitor(QuestionInDBBase):
-    desc: Optional[RichText] = None
-    comments: List[CommentForVisitor]
-    answers_count: int
-    author: UserPreview
-    site: Site
-    upvotes: Optional[QuestionUpvotes] = None
+    upvoted: bool = False
 
 
 # Additional properties stored in DB
@@ -91,8 +83,8 @@ class QuestionPreviewForSearch(BaseModel):
     uuid: str
     title: str
 
-#class QuestionPreviewForVisitor(QuestionPreviewForSearch):
-class QuestionPreviewForVisitor(BaseModel):
+
+class QuestionPreview(BaseModel):
     uuid: str
     title: str
     author: UserPreview
@@ -101,9 +93,6 @@ class QuestionPreviewForVisitor(BaseModel):
     created_at: datetime.datetime
     answers_count: int
     upvotes: Optional[QuestionUpvotes]
-
-
-class QuestionPreview(QuestionPreviewForVisitor):
     site: Site
     upvotes_count: int
     comments_count: int

--- a/chafan_core/app/schemas/question_page.py
+++ b/chafan_core/app/schemas/question_page.py
@@ -1,13 +1,8 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from pydantic import BaseModel
 
-from chafan_core.app.schemas.answer import (
-    Answer,
-    AnswerForVisitor,
-    AnswerPreview,
-    AnswerPreviewForVisitor,
-)
+from chafan_core.app.schemas.answer import Answer, AnswerPreview
 from chafan_core.app.schemas.question import Question
 from chafan_core.app.schemas.user import UserQuestionSubscription
 
@@ -22,7 +17,7 @@ class QuestionPageFlags(BaseModel):
 
 class QuestionPage(BaseModel):
     question: Question
-    full_answers: List[Union[Answer, AnswerForVisitor]]
-    answer_previews: List[Union[AnswerPreview, AnswerPreviewForVisitor]]
+    full_answers: List[Answer]
+    answer_previews: List[AnswerPreview]
     question_subscription: Optional[UserQuestionSubscription]
     flags: QuestionPageFlags

--- a/chafan_core/app/schemas/question_page.py
+++ b/chafan_core/app/schemas/question_page.py
@@ -8,7 +8,7 @@ from chafan_core.app.schemas.answer import (
     AnswerPreview,
     AnswerPreviewForVisitor,
 )
-from chafan_core.app.schemas.question import Question, QuestionForVisitor
+from chafan_core.app.schemas.question import Question
 from chafan_core.app.schemas.user import UserQuestionSubscription
 
 
@@ -21,7 +21,7 @@ class QuestionPageFlags(BaseModel):
 
 
 class QuestionPage(BaseModel):
-    question: Union[Question, QuestionForVisitor]
+    question: Question
     full_answers: List[Union[Answer, AnswerForVisitor]]
     answer_previews: List[Union[AnswerPreview, AnswerPreviewForVisitor]]
     question_subscription: Optional[UserQuestionSubscription]

--- a/chafan_core/app/schemas/submission.py
+++ b/chafan_core/app/schemas/submission.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import BaseModel, validator
 from pydantic.networks import AnyHttpUrl
 
-from chafan_core.app.schemas.comment import Comment, CommentForVisitor
+from chafan_core.app.schemas.comment import Comment
 from chafan_core.app.schemas.preview import UserPreview
 from chafan_core.app.schemas.richtext import RichText
 from chafan_core.app.schemas.site import Site
@@ -58,7 +58,7 @@ class SubmissionInDB(SubmissionBase):
         from_attributes = True
 
 
-# Additional properties to return via API
+# One schema for any principal allowed to read the submission
 class Submission(SubmissionInDB):
     desc: Optional[RichText] = None
     author: UserPreview
@@ -66,14 +66,6 @@ class Submission(SubmissionInDB):
     comments: List[Comment]
     site: Site
     view_times: int
-
-
-class SubmissionForVisitor(SubmissionInDB):
-    desc: Optional[RichText]
-    author: UserPreview
-    contributors: List[UserPreview] = []
-    site: Site
-    comments: List[CommentForVisitor]
 
 
 class SubmissionUpvotes(BaseModel):

--- a/chafan_core/app/schemas/user.py
+++ b/chafan_core/app/schemas/user.py
@@ -131,7 +131,13 @@ class UserInDBBase(UserBase):
         from_attributes = True
 
 
-class UserPublicForVisitor(UserPreview):
+class YearContributions(BaseModel):
+    year: int
+    data: List[int]
+
+
+# One public profile schema for any principal allowed to view the user.
+class UserPublic(UserPreview):
     gif_avatar_url: Optional[AnyHttpUrl] = None
     answers_count: int
     submissions_count: int
@@ -139,25 +145,17 @@ class UserPublicForVisitor(UserPreview):
     articles_count: int
     created_at: datetime.datetime
     profile_view_times: int
-
-
-class YearContributions(BaseModel):
-    year: int
-    data: List[int]
-
-
-class UserPublic(UserPublicForVisitor):
-    about_content: Optional[RichText]
+    about_content: Optional[RichText] = None
     # deprecated
-    profiles: List[Profile]
-    residency_topics: List[Topic]
-    profession_topics: List[Topic]
+    profiles: List[Profile] = []
+    residency_topics: List[Topic] = []
+    profession_topics: List[Topic] = []
     github_username: Optional[str] = None
     twitter_username: Optional[str] = None
     linkedin_url: Optional[AnyHttpUrl] = None
     homepage_url: Optional[AnyHttpUrl] = None
     zhihu_url: Optional[AnyHttpUrl] = None
-    subscribed_topics: List[Topic]
+    subscribed_topics: List[Topic] = []
     work_exps: List[UserWorkExperience] = []
     edu_exps: List[UserEducationExperience] = []
     contributions: Optional[List[YearContributions]] = None

--- a/chafan_core/app/task.py
+++ b/chafan_core/app/task.py
@@ -2,8 +2,6 @@ import datetime
 from typing import List, Optional
 
 from collections import Counter
-import dramatiq
-from dramatiq.brokers.redis import RedisBroker
 from sqlalchemy.orm.session import Session
 
 
@@ -66,12 +64,6 @@ import chafan_core.app.rep_manager as rep
 import logging
 logger = logging.getLogger(__name__)
 
-
-# TODO do we need a better way to get url?
-redis_url = settings.REDIS_URL
-logger.info(f"Create DramatiqBroker with redis {redis_url}")
-dramatiq_broker = RedisBroker(url=redis_url, namespace="dramatiq")
-dramatiq.set_broker(dramatiq_broker)
 
 
 
@@ -146,7 +138,6 @@ def get_comment_event(comment: models.Comment) -> Optional[EventInternal]:
     return None
 
 
-@dramatiq.actor
 def postprocess_new_comment(
     comment_id: int, shared_to_timeline: bool, mentioned: Optional[List[str]]
 ) -> None:
@@ -217,7 +208,6 @@ def postprocess_new_comment(
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_comment_update(
     comment_id: int,
     was_shared_to_timeline: bool,
@@ -249,12 +239,10 @@ def postprocess_comment_update(
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_question_common(question: models.Question) -> None:
     update_question_keywords(question)
 
 
-@dramatiq.actor
 def postprocess_new_question(question_id: int) -> None:
     print("postprocess_new_question")
 
@@ -293,7 +281,6 @@ def postprocess_new_question(question_id: int) -> None:
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_updated_question(question_id: int) -> None:
     print("postprocess_updated_question")
 
@@ -323,7 +310,6 @@ def postprocess_submission_common(submission: models.Submission) -> None:
     update_submission_keywords(submission)
 
 
-@dramatiq.actor
 def postprocess_new_submission(submission_id: int) -> None:
     def runnable(broker: DataBroker) -> None:
         submission = crud.submission.get(broker.get_db(), id=submission_id)
@@ -350,7 +336,6 @@ def postprocess_new_submission(submission_id: int) -> None:
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_new_submission_suggestion(submission_suggestion_id: int) -> None:
     def runnable(broker: DataBroker) -> None:
         submission_suggestion = crud.submission_suggestion.get(
@@ -378,7 +363,6 @@ def postprocess_new_submission_suggestion(submission_suggestion_id: int) -> None
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_accept_submission_suggestion(submission_suggestion_id: int) -> None:
     def runnable(db: Session) -> None:
         submission_suggestion = crud.submission_suggestion.get(
@@ -400,7 +384,6 @@ def postprocess_accept_submission_suggestion(submission_suggestion_id: int) -> N
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def postprocess_new_answer_suggest_edit(answer_suggest_edit_id: int) -> None:
     def runnable(broker: DataBroker) -> None:
         answer_suggest_edit = crud.answer_suggest_edit.get(
@@ -427,7 +410,6 @@ def postprocess_new_answer_suggest_edit(answer_suggest_edit_id: int) -> None:
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_accept_answer_suggest_edit(answer_suggest_edit_id: int) -> None:
     def runnable(db: Session) -> None:
         answer_suggest_edit = crud.answer_suggest_edit.get(
@@ -449,7 +431,6 @@ def postprocess_accept_answer_suggest_edit(answer_suggest_edit_id: int) -> None:
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def postprocess_updated_submission(submission_id: int) -> None:
     def runnable(db: Session) -> None:
         submission = crud.submission.get(db, id=submission_id)
@@ -459,7 +440,6 @@ def postprocess_updated_submission(submission_id: int) -> None:
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def postprocess_new_answer(answer_id: int, was_published: bool) -> None:
     def runnable(broker: DataBroker) -> None:
         answer = crud.answer.get(broker.get_db(), id=answer_id)
@@ -510,7 +490,6 @@ def postprocess_new_answer(answer_id: int, was_published: bool) -> None:
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_new_article(article_id: int) -> None:
     def runnable(broker: DataBroker) -> None:
         article = crud.article.get(broker.get_db(), id=article_id)
@@ -543,7 +522,6 @@ def postprocess_new_article(article_id: int) -> None:
     execute_with_broker(runnable)
 
 
-@dramatiq.actor
 def postprocess_updated_article(article_id: int, was_published: bool) -> None:
     def runnable(db: Session) -> None:
         article = crud.article.get(db, id=article_id)
@@ -557,7 +535,6 @@ def postprocess_updated_article(article_id: int, was_published: bool) -> None:
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def postprocess_new_feedback(feedback_id: int) -> None:
     def runnable(db: Session) -> None:
         feedback = (
@@ -570,7 +547,6 @@ def postprocess_new_feedback(feedback_id: int) -> None:
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def refresh_interesting_question_ids_for_user(user_id: int) -> None:
     def runnable(db: Session) -> None:
         user = crud.user.get(db, user_id)
@@ -589,7 +565,6 @@ def refresh_interesting_question_ids_for_user(user_id: int) -> None:
     execute_with_db(SessionLocal(), runnable)
 
 
-@dramatiq.actor
 def refresh_interesting_user_ids_for_user(user_id: int) -> None:
     def runnable(db: Session) -> None:
         user = crud.user.get(db, user_id)

--- a/chafan_core/app/user_permission.py
+++ b/chafan_core/app/user_permission.py
@@ -4,11 +4,11 @@ from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models
 from chafan_core.app.common import OperationType
-from chafan_core.app.config import settings
+from chafan_core.app.model_utils import is_live_answer
 from chafan_core.utils.base import ContentVisibility
 
-
 import logging
+
 logger = logging.getLogger(__name__)
 
 # TODO everything about user permission, including if they can create a site (KARMA), invite a user, write an answer, etc, should be moved into this file. 2025-07-08
@@ -19,12 +19,18 @@ def get_active_site_profile(
 ) -> Optional[models.Profile]:
     return crud.profile.get_by_user_and_site(db, owner_id=user_id, site_id=site.id)
 
+
 def user_in_site(
     db: Session,
     site: models.Site,
-    user_id: int,
+    user_id: Optional[int],
     op_type: OperationType,
 ) -> bool:
+    """Site membership / public-flag check for a principal.
+
+    Anonymous principals (user_id is None) only succeed when the site's public
+    flag for the given op_type allows the operation without membership.
+    """
     if op_type == OperationType.ReadSite and site.public_readable:
         return True
     if op_type == OperationType.WriteSiteAnswer and site.public_writable_answer:
@@ -35,14 +41,18 @@ def user_in_site(
         return True
     if op_type == OperationType.WriteSiteComment and site.public_writable_comment:
         return True
+    if user_id is None:
+        return False
     if get_active_site_profile(db, site=site, user_id=user_id) is None:
         return False
     if op_type == OperationType.AddSiteMember and not site.addable_member:
         return False
     return True
 
+
 def article_read_allowed(
-    db: Session, article: models.Article, user_id: Optional[int]) -> bool:
+    db: Session, article: models.Article, user_id: Optional[int]
+) -> bool:
     if article.is_published and article.visibility == ContentVisibility.ANYONE:
         return True
     if article.author_id == user_id and user_id is not None:
@@ -51,8 +61,10 @@ def article_read_allowed(
     logger.info(f"User {user_id} is not allowed to read article {article.id}")
     return False
 
+
 def question_read_allowed(
-    cached_layer, question: models.Question, user_id: Optional[int]) -> bool:
+    cached_layer, question: models.Question, user_id: Optional[int]
+) -> bool:
     if not question.is_hidden:
         return True
     if user_id is not None and user_id == question.author_id:
@@ -63,3 +75,24 @@ def question_read_allowed(
     return False
 
 
+def answer_read_allowed(
+    db: Session, answer: models.Answer, user_id: Optional[int]
+) -> bool:
+    """Binary read gate for answers: allowed → full schema; denied → no payload.
+
+    Matches the prior materialize split: authors always; live answers for site
+    members / public-read; anonymous additionally requires ANYONE visibility.
+    """
+    if answer.is_deleted:
+        return False
+    if user_id is not None and user_id == answer.author_id:
+        return True
+    if not is_live_answer(answer):
+        return False
+    if user_id is None:
+        if answer.visibility != ContentVisibility.ANYONE:
+            return False
+        return bool(answer.site.public_readable)
+    return user_in_site(
+        db, site=answer.site, user_id=user_id, op_type=OperationType.ReadSite
+    )

--- a/chafan_core/app/webhook_utils.py
+++ b/chafan_core/app/webhook_utils.py
@@ -9,7 +9,7 @@ from pydantic.tools import parse_obj_as
 from chafan_core.app import models
 from chafan_core.app.cached_layer import CachedLayer
 from chafan_core.app.common import is_dev
-from chafan_core.app.schemas import AnswerPreviewForVisitor, QuestionPreviewForVisitor
+from chafan_core.app.schemas import AnswerPreviewForVisitor, QuestionPreview
 from chafan_core.app.schemas.submission import SubmissionForVisitor
 from chafan_core.app.schemas.webhook import WebhookEventSpec, WebhookSiteEvent
 
@@ -33,7 +33,7 @@ class NewAnswerEventDetails(BaseModel):
 
 class NewQuestionEventDetails(BaseModel):
     sub_type: Literal["new_question"] = "new_question"
-    question_preview: QuestionPreviewForVisitor
+    question_preview: QuestionPreview
 
 
 class NewSubmissionEventDetails(BaseModel):
@@ -94,9 +94,7 @@ def call_webhook(
             and event_spec_content.new_question
         ):
             question_preview = (
-                cached_layer.materializer.preview_of_question_for_visitor(
-                    event.question
-                )
+                cached_layer.materializer.preview_of_question(event.question)
             )
             if question_preview:
                 _post_webhook(

--- a/chafan_core/app/webhook_utils.py
+++ b/chafan_core/app/webhook_utils.py
@@ -9,7 +9,7 @@ from pydantic.tools import parse_obj_as
 from chafan_core.app import models
 from chafan_core.app.cached_layer import CachedLayer
 from chafan_core.app.common import is_dev
-from chafan_core.app.schemas import AnswerPreviewForVisitor, QuestionPreview
+from chafan_core.app.schemas import AnswerPreview, QuestionPreview
 from chafan_core.app.schemas.submission import SubmissionForVisitor
 from chafan_core.app.schemas.webhook import WebhookEventSpec, WebhookSiteEvent
 
@@ -28,7 +28,7 @@ class SiteNewSubmissionEvent(NamedTuple):
 
 class NewAnswerEventDetails(BaseModel):
     sub_type: Literal["new_answer"] = "new_answer"
-    answer_preview: AnswerPreviewForVisitor
+    answer_preview: AnswerPreview
 
 
 class NewQuestionEventDetails(BaseModel):
@@ -77,7 +77,7 @@ def call_webhook(
             isinstance(event_spec_content, WebhookSiteEvent)
             and event_spec_content.new_answer
         ):
-            answer_preview = cached_layer.materializer.preview_of_answer_for_visitor(
+            answer_preview = cached_layer.materializer.preview_of_answer(
                 event.answer
             )
             if answer_preview:

--- a/chafan_core/app/webhook_utils.py
+++ b/chafan_core/app/webhook_utils.py
@@ -10,7 +10,7 @@ from chafan_core.app import models
 from chafan_core.app.cached_layer import CachedLayer
 from chafan_core.app.common import is_dev
 from chafan_core.app.schemas import AnswerPreview, QuestionPreview
-from chafan_core.app.schemas.submission import SubmissionForVisitor
+from chafan_core.app.schemas.submission import Submission
 from chafan_core.app.schemas.webhook import WebhookEventSpec, WebhookSiteEvent
 
 
@@ -38,7 +38,7 @@ class NewQuestionEventDetails(BaseModel):
 
 class NewSubmissionEventDetails(BaseModel):
     sub_type: Literal["new_submission"] = "new_submission"
-    submission: SubmissionForVisitor
+    submission: Submission
 
 
 class WebhookEvent(BaseModel):

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
           ps.passlib
           ps.boto3 # S3 client
           ps.bcrypt
-          ps.dramatiq
           ps.sentry-sdk
 
           ps.pydantic

--- a/scripts/e2e/run_e2e_smoke.sh
+++ b/scripts/e2e/run_e2e_smoke.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # End-to-end smoke run in *bootstrap* mode.
 #
-#   fresh DB -> migrate -> seed fixtures -> live uvicorn + dramatiq -> smoke suite
+#   fresh DB -> migrate -> seed fixtures -> live uvicorn -> smoke suite
 #
 # Preconditions (the caller sets these up):
 #   - cwd is the repo root,
 #   - a Postgres + Redis reachable per DATABASE_URL / REDIS_URL are up,
 #   - the app env is already sourced (e.g. `source env.ci`),
-#   - we are inside the nix devShell so uvicorn/dramatiq/alembic are on PATH.
+#   - we are inside the nix devShell so uvicorn/alembic are on PATH.
 #
 # In CI this runs inside `nix develop --command`. Locally you can run it the
 # same way from a checkout with Postgres/Redis available.
 #
-# Exit 0 = smoke suite passed. Non-zero = something regressed; server and
-# worker logs are dumped to aid diagnosis.
+# Exit 0 = smoke suite passed. Non-zero = something regressed; server logs
+# are dumped to aid diagnosis.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
@@ -27,14 +27,10 @@ READY_TIMEOUT=60
 
 LOG_DIR="$(mktemp -d)"
 SERVER_LOG="$LOG_DIR/uvicorn.log"
-WORKER_LOG="$LOG_DIR/dramatiq.log"
 
 server_pid=""
-worker_pid=""
 
 dump_logs() {
-    echo "----- dramatiq worker log -----"
-    tail -n 100 "$WORKER_LOG" 2>/dev/null || true
     echo "----- uvicorn server log -----"
     tail -n 100 "$SERVER_LOG" 2>/dev/null || true
 }
@@ -42,7 +38,6 @@ dump_logs() {
 cleanup() {
     local code=$?
     [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
-    [ -n "$worker_pid" ] && kill "$worker_pid" 2>/dev/null || true
     if [ "$code" -ne 0 ]; then
         echo "==> e2e smoke FAILED (exit $code); dumping logs"
         dump_logs
@@ -60,10 +55,6 @@ python scripts/initial_data.py
 echo "==> Seed bootstrap fixtures (writes smoke/config.json)"
 python smoke/seed.py
 
-echo "==> Launch dramatiq worker"
-dramatiq --threads 2 chafan_core.app.task >"$WORKER_LOG" 2>&1 &
-worker_pid=$!
-
 echo "==> Launch uvicorn server"
 uvicorn chafan_core.app.main:app --host "$HOST_ADDR" --port "$PORT" \
     >"$SERVER_LOG" 2>&1 &
@@ -72,13 +63,6 @@ server_pid=$!
 echo "==> Wait for server readiness"
 if ! python scripts/e2e/wait_ready.py "$READY_URL" "$READY_TIMEOUT"; then
     echo "server never became ready" >&2
-    exit 1
-fi
-
-# A dead worker would make s10/s11 fan-out polling time out and read as a
-# real regression, so fail fast and clearly if it already crashed.
-if ! kill -0 "$worker_pid" 2>/dev/null; then
-    echo "dramatiq worker exited before smoke run" >&2
     exit 1
 fi
 

--- a/scripts/launch_serv/3_dramatiq_screen.sh
+++ b/scripts/launch_serv/3_dramatiq_screen.sh
@@ -1,5 +1,0 @@
-base=$(git rev-parse --show-toplevel)
-cd "$base"
-
-screen -S dramatiq bash -c \
-    "nix develop --command $base/scripts/launch_serv/_dramatiq.sh"

--- a/scripts/launch_serv/_dramatiq.sh
+++ b/scripts/launch_serv/_dramatiq.sh
@@ -1,9 +1,0 @@
-set -ex
-
-base=$(git rev-parse --show-toplevel)
-cd "$base"
-source $base/../launch_env
-
-dramatiq --threads 2 chafan_core.app.task
-
-

--- a/smoke/scenarios/s10_feed_fanout.py
+++ b/smoke/scenarios/s10_feed_fanout.py
@@ -1,7 +1,7 @@
 """s10 — feed fan-out (the high-value activity test).
 
 Positive: A follows B, B posts a fresh question, A's feed should eventually
-contain it. Polled because fan-out is via dramatiq.
+contain it. Polled because fan-out is post-response (BackgroundTasks).
 
 Negative: A unfollows B, B posts another question, A's feed should NOT
 contain it. We can't poll for absence, so we sleep at least as long as the

--- a/smoke/scenarios/s11_notifications.py
+++ b/smoke/scenarios/s11_notifications.py
@@ -8,7 +8,7 @@ mentioned list (backend does not parse @ from the body — clients supply
 the list explicitly via CommentCreate.mentioned). B gets a notification
 that references A's comment.
 
-Both sub-flows are polled because the fan-out is via dramatiq.
+Both sub-flows are polled because the fan-out is post-response (BackgroundTasks).
 """
 from __future__ import annotations
 

--- a/smoke/seed.py
+++ b/smoke/seed.py
@@ -43,7 +43,7 @@ from chafan_core.utils.validators import (
 )
 
 API_BASE = os.environ.get("SMOKE_API_BASE", "http://127.0.0.1:8000")
-# Generous for a cold CI runner: s10/s11 poll dramatiq fan-out.
+# Generous for a cold CI runner: s10/s11 poll post-response fan-out.
 POLL_TIMEOUT_SECONDS = int(os.environ.get("SMOKE_POLL_TIMEOUT_SECONDS", "60"))
 
 SITE_SUBDOMAIN = "smoke"


### PR DESCRIPTION
Part of the backend re-design stack.

**Stacked PR** — base branch: `dev/step-2-remove-dramatiq`. Review only the incremental diff (this PR = one step of the stack).

Commits in this step:
- Kill answer ForVisitor schemas; one answer path (Step 1)
- Route answer responses through CachedLayer after materialize kill