### PR TITLE
Drop content caches from CachedLayer (Step 3)

### DIFF
--- a/chafan_core/app/api/deps.py
+++ b/chafan_core/app/api/deps.py
@@ -8,6 +8,7 @@ from chafan_core.app import schemas, security
 from chafan_core.app.cached_layer import CachedLayer
 from chafan_core.app.config import settings
 from chafan_core.app.data_broker import DataBroker
+from chafan_core.app.infra.request_context import RequestContext
 from chafan_core.utils.base import HTTPException_, unwrap
 
 reusable_oauth2 = OAuth2PasswordBearer(
@@ -49,6 +50,31 @@ def try_get_current_user_id(
         return None
 
 
+def get_request_context(
+    current_user_id: Optional[int] = Depends(try_get_current_user_id),
+) -> Generator:
+    """Preferred per-request context (principal + lazy db/redis).
+
+    close_legacy_commit keeps historical request-end commit behavior until
+    services own transaction boundaries.
+    """
+    ctx = RequestContext(principal_id=current_user_id)
+    try:
+        yield ctx
+    finally:
+        ctx.close_legacy_commit()
+
+
+def get_request_context_logged_in(
+    current_user_id: int = Depends(get_current_user_id),
+) -> Generator:
+    ctx = RequestContext(principal_id=current_user_id)
+    try:
+        yield ctx
+    finally:
+        ctx.close_legacy_commit()
+
+
 def get_data_broker_with_params(*, use_read_replica: bool = False) -> Any:
     def _f() -> Generator:
         try:
@@ -84,6 +110,7 @@ def get_db(
 
 
 def get_read_db(
-    broker: DataBroker = Depends(get_data_broker_with_params(use_read_replica=True)),
+    broker: DataBroker = Depends(get_data_broker_with_params(use_read_replica=False)),
 ) -> Generator:
+    # D6: no read replica — same session factory as get_db.
     yield broker.get_db()

--- a/chafan_core/app/cached_layer.py
+++ b/chafan_core/app/cached_layer.py
@@ -97,6 +97,9 @@ class CachedLayer(object):
     def unwrapped_principal_id(self) -> int:
         return unwrap(self.principal_id)
 
+    # Content caching removed (D1 / target architecture Step 3).
+    # Redis remains for ephemeral state only (OTP, view-bump queue, daily invitation id).
+
     def _get_cached_not_none(
         self,
         *,
@@ -105,18 +108,7 @@ class CachedLayer(object):
         fallable_fetch: Callable[[], Optional[T]],
         hours: int,
     ) -> Optional[T]:
-        redis_cli = self.get_redis()
-        value = redis_cli.get(key)
-        if value is not None:
-            TypeAdapter(typeObj).validate_json(value)
-        data = fallable_fetch()
-        if data and not is_dev():
-            redis_cli.set(
-                key,
-                json.dumps(jsonable_encoder(data)),
-                ex=datetime.timedelta(hours=hours),
-            )
-        return data
+        return fallable_fetch()
 
     def _get_cached(
         self,
@@ -127,18 +119,21 @@ class CachedLayer(object):
         hours: int,
         cache_if_dev: bool = False,
     ) -> T:
-        redis_cli = self.get_redis()
-        value = redis_cli.get(key)
-        if value is not None:
-            return TypeAdapter(typeObj).validate_json(value)
-        data = fetch()
-        if data and (not is_dev() or cache_if_dev):
-            redis_cli.set(
-                key,
-                json.dumps(jsonable_encoder(data)),
-                ex=datetime.timedelta(hours=hours),
-            )
-        return data
+        # Exception: daily invitation link id is operational state, not content cache.
+        if key == DAILY_INVITATION_LINK_ID_CACHE_KEY:
+            redis_cli = self.get_redis()
+            value = redis_cli.get(key)
+            if value is not None:
+                return TypeAdapter(typeObj).validate_json(value)
+            data = fetch()
+            if data is not None:
+                redis_cli.set(
+                    key,
+                    json.dumps(jsonable_encoder(data)),
+                    ex=datetime.timedelta(hours=hours),
+                )
+            return data
+        return fetch()
 
     def _get_cached_non_empty(
         self,
@@ -148,19 +143,7 @@ class CachedLayer(object):
         fallable_fetch: Callable[[], List[T]],
         hours: int,
     ) -> List[T]:
-        redis_cli = self.get_redis()
-        value = redis_cli.get(key)
-        if value is not None:
-            logger.info(f"redis hit for {key}")
-            return TypeAdapter(typeObj).validate_json(value)
-        data = fallable_fetch()
-        if data:
-            redis_cli.set(
-                key,
-                json.dumps(jsonable_encoder(data)),
-                ex=datetime.timedelta(hours=hours),
-            )
-        return data
+        return fallable_fetch()
 
     def question_schema_from_orm(self, question: models.Question) -> Optional[schemas.Question]:
         logger.info("called cached.layer for question " + str(question))
@@ -228,26 +211,14 @@ class CachedLayer(object):
         # )
 
     def invalidate_answer_cache(self, uuid: str) -> None:
-        redis_cli = self.get_redis()
-        redis_cli.delete(ANSWER_CACHE_KEY.format(uuid=uuid))
-        redis_cli.delete(ANSWER_FOR_VISITOR_CACHE_KEY.format(uuid=uuid))
+        return
 
     def _get_cached_recent_k_submissions_of_site(
         self, site: models.Site, k: int
     ) -> List[schemas.Submission]:
-        redis = self.broker.get_redis()
-        key = f"chafan:cached-recent-k-submissions-of-site:{site.id}:{k}"
-        value = redis.get(key)
-        if value is not None:
-            return TypeAdapter(List[schemas.Submission]).validate_json(value)
-        data = filter_not_none(
+        return filter_not_none(
             [self.materializer.submission_schema_from_orm(s) for s in site.submissions]
         )[:k]
-        if not is_dev():
-            redis.set(
-                key, json.dumps(jsonable_encoder(data)), ex=datetime.timedelta(hours=24)
-            )
-        return data
 
     def _get_submissions_for_user(
         self, current_user_id: Optional[int]
@@ -288,39 +259,16 @@ class CachedLayer(object):
         return crud.site.get_by_subdomain(self.get_db(), subdomain=subdomain)
 
     def get_site_info(self, *, subdomain: str) -> Optional[schemas.Site]:
-        redis_cli = self.get_redis()
-        key = SITE_INFO_CACHE_KEY.format(subdomain=subdomain)
-        value = redis_cli.get(key)
-        if value is not None:
-            return schemas.Site.model_validate_json(value)
         site = crud.site.get_by_subdomain(self.get_db(), subdomain=subdomain)
         if site is None:
             return None
-        site_data = self.site_schema_from_orm(site)
-        if not is_dev():
-            redis_cli.set(key, site_data.json(), ex=datetime.timedelta(hours=24))
-        return site_data
+        return self.site_schema_from_orm(site)
 
     def get_site_submissions_for_user(
         self, *, site: models.Site, user_id: Optional[int], skip: int, limit: int
     ) -> List[schemas.Submission]:
-        redis = self.get_redis()
-        key = SITE_SUBMISSIONS_FOR_USER_CACHE_KEY.format(
-            site_id=site.id, user_id=user_id
-        )
-        value = redis.get(key)
-        if value is not None:
-            if user_id:
-                return TypeAdapter(List[schemas.Submission]).validate_json(value)[
-                    skip : skip + limit
-                ]
-            else:
-                return TypeAdapter(List[schemas.Submission]).validate_json(
-                    value
-                )[skip : skip + limit]
         submissions: List[Any] = []
         if user_id:
-            # FIXME: compute rank async
             submissions = rank_submissions(
                 filter_not_none(
                     [
@@ -330,24 +278,14 @@ class CachedLayer(object):
                 )
             )
         else:
-            # FIXME: compute rank async
-            logger.error("TODO submission list for visitors are turned off due to `desc` missing") #2025-Jul-30
-            submissions = []
-            # submissions = rank_submissions(
-            #     filter_not_none(
-            #         [
-            #             self.materializer.submission_for_visitor_schema_from_orm(
-            #                 submission
-            #             )
-            #             for submission in site.submissions[:10]
-            #         ]
-            #     )
-            # )
-        if False and not is_dev():
-            redis.set(
-                key,
-                json.dumps(jsonable_encoder(submissions)),
-                ex=datetime.timedelta(hours=1),
+            # Public site lists: same schema path for any allowed reader.
+            submissions = rank_submissions(
+                filter_not_none(
+                    [
+                        self.materializer.submission_schema_from_orm(submission)
+                        for submission in site.submissions
+                    ]
+                )
             )
         return submissions[skip : skip + limit]
 
@@ -355,15 +293,9 @@ class CachedLayer(object):
         self, *, old_site: models.Site, update_dict: Dict[str, Any]
     ) -> models.Site:
         site = crud.site.update(self.get_db(), db_obj=old_site, obj_in=update_dict)
-        self.get_redis().delete(SITEMAPS_CACHE_KEY)
-        self.get_redis().delete(SITE_INFO_CACHE_KEY.format(subdomain=site.subdomain))
         return site
 
     def get_site_maps(self) -> schemas.site.SiteMaps:
-        redis_cli = self.get_redis()
-        value = redis_cli.get(SITEMAPS_CACHE_KEY)
-        if value is not None:
-            return schemas.site.SiteMaps.model_validate_json(value)
         read_db = self.get_db()
         sites = crud.site.get_all(read_db)
         site_maps: Dict[str, schemas.site.SiteMap] = {}
@@ -375,13 +307,10 @@ class CachedLayer(object):
             if s.category_topic is not None:
                 logger.error("site category_topic is deprecated")
             sites_without_topics.append(site_data)
-        data = schemas.site.SiteMaps(
+        return schemas.site.SiteMaps(
             site_maps=list(site_maps.values()),
             sites_without_topics=sites_without_topics,
         )
-        redis_cli.set(
-            SITEMAPS_CACHE_KEY, data.json(), ex=settings.CACHE_SITEMAP_VALID_HOURS)
-        return data
 
     def create_site(
         self,
@@ -396,24 +325,13 @@ class CachedLayer(object):
             moderator=moderator,
             category_topic_id=category_topic_id,
         )
-        self.get_redis().delete(SITEMAPS_CACHE_KEY)
         return site
 
     def get_redis(self) -> redis.Redis:
         return self.broker.get_redis()
 
     def invalidate_submission_caches(self, submission: models.Submission) -> None:
-        redis_cli = self.get_redis()
-        redis_cli.delete(
-            SUBMISSIONS_FOR_USER_CACHE_KEY.format(user_id=submission.author_id)
-        )
-        redis_cli.delete(SITE_SUBMISSIONS_CACHE_KEY.format(site_id=submission.site_id))
-        for k in redis_cli.scan_iter(
-            SITE_SUBMISSIONS_FOR_USER_CACHE_KEY.format(
-                site_id=submission.site_id, user_id="*"
-            )
-        ):
-            redis_cli.delete(k)
+        return
 
     def is_valid_verification_code(self, email: str, code: str) -> bool:
         key = VERIFICATION_CODE_CACHE_KEY.format(email=email)
@@ -423,11 +341,6 @@ class CachedLayer(object):
         return value == code
 
     def get_answer_upvotes(self, uuid: str) -> Optional[schemas.AnswerUpvotes]:
-        redis_cli = self.get_redis()
-        key = ANSWER_UPVOTES_CACHE_KEY.format(uuid=uuid, user_id=self.principal_id)
-        value = redis_cli.get(key)
-        if value is not None:
-            return schemas.AnswerUpvotes.model_validate_json(value)
         db = self.get_db()
         answer = crud.answer.get_by_uuid(db, uuid=uuid)
         if answer is None:
@@ -447,12 +360,9 @@ class CachedLayer(object):
             .filter_by(answer_id=answer.id, cancelled=False)
             .count()
         )
-        data = schemas.AnswerUpvotes(
+        return schemas.AnswerUpvotes(
             answer_uuid=answer.uuid, count=valid_upvotes, upvoted=upvoted
         )
-        if not is_dev():
-            redis_cli.set(key, data.json(), ex=datetime.timedelta(hours=6))
-        return data
 
     def delete_answer(self, uuid: str) -> Optional[str]:
         """Returns error msg"""
@@ -467,9 +377,7 @@ class CachedLayer(object):
         return None
 
     def invalidate_answer_upvotes_cache(self, uuid: str) -> None:
-        self.get_redis().delete(
-            ANSWER_UPVOTES_CACHE_KEY.format(uuid=uuid, user_id=self.principal_id)
-        )
+        return
 
     def invalidate_comment_caches(self, comment: models.Comment) -> None:
         if comment.answer:
@@ -598,30 +506,14 @@ class CachedLayer(object):
         notif: models.Notification,
         notif_in: schemas.NotificationUpdate,
     ) -> None:
-        notif = crud.notification.update(self.get_db(), db_obj=notif, obj_in=notif_in)
-        self.get_redis().delete(
-            NOTIF_FOR_RECEIVER_CACHE_KEY.format(
-                notification_id=notif.id,
-                receiver_id=notif.receiver_id,
-            )
-        )
+        crud.notification.update(self.get_db(), db_obj=notif, obj_in=notif_in)
 
     def notification_schema_from_orm(
         self, notif: models.Notification
     ) -> Optional[schemas.Notification]:
         if self.principal_id is None:
             return None
-        key = NOTIF_FOR_RECEIVER_CACHE_KEY.format(
-            notification_id=notif.id, receiver_id=self.principal_id
-        )
-        redis_cli = self.get_redis()
-        value = redis_cli.get(key)
-        if value is not None:
-            return schemas.Notification.model_validate_json(value)
-        data = self.materializer.notification_schema_from_orm(notif)
-        if data and not is_dev():
-            redis_cli.set(key, data.json(), ex=datetime.timedelta(hours=24))
-        return data
+        return self.materializer.notification_schema_from_orm(notif)
 
     def get_question_by_id(self, question_id: int):
         question = crud.question.get_by_id(self.get_db(), id=question_id)
@@ -804,19 +696,8 @@ class CachedLayer(object):
             random:bool,
             subject_user_uuid: Optional[str]):
         logger.info(f"cached_layer get_user_activity for {current_user_id}")
-        redis = self.get_redis()
-        key = f"chafan:feed-cache:user:{current_user_id}:before_activity_id={before_activity_id}&limit={limit}&subject_user_uuid={subject_user_uuid}"
-        value = redis.get(key)
-        value = None
-        if value: # TODO redis cache is broken for now 2025-08-04
-            return None
-#            return _update_feed_seq(
-#                cached_layer,
-#                schemas.FeedSequence.model_validate_json(value),
-#                full_answers=full_answers,
-#            )
         activities = get_activities_v2(
-            cached_layer = self,
+            cached_layer=self,
             before_activity_id=before_activity_id,
             limit=limit,
             receiver_user_id=current_user_id,
@@ -833,7 +714,6 @@ class CachedLayer(object):
             and insufficient > 0
             and subject_user_uuid is None
         ):
-            random = True
             extra_activities = get_random_activities(
                 receiver_user_id=current_user_id,
                 before_activity_id=before_activity_id,
@@ -841,12 +721,6 @@ class CachedLayer(object):
             )
             activities.extend(extra_activities)
 
-        redis.delete(key)
-        redis.set( # TODO fixme
-            key,
-            json.dumps(jsonable_encoder(1)),
-            ex=datetime.timedelta(minutes=1),
-        )
         return activities
 
 
@@ -955,14 +829,12 @@ class CachedLayer(object):
                 site_uuid=site_uuid,
             ),
         )
-        self.get_redis().delete(USER_SITE_PROFILES.format(user_id=owner.id))
         return self.materializer.profile_schema_from_orm(data)
 
     def remove_site_profile(self, *, owner_id: int, site_id: int) -> None:
         crud.profile.remove_by_user_and_site(
             self.get_db(), owner_id=owner_id, site_id=site_id
         )
-        self.get_redis().delete(USER_SITE_PROFILES.format(user_id=owner_id))
 
 
     # TODO maybe this is not the best place to put it  2025-Jul-06

--- a/chafan_core/app/data_broker.py
+++ b/chafan_core/app/data_broker.py
@@ -5,13 +5,17 @@ as a thin compatibility wrapper used by CachedLayer and existing call sites.
 use_read_replica is ignored (D6: single Postgres, no replica).
 """
 
-from typing import Optional
+from __future__ import annotations
 
-import redis
+from typing import TYPE_CHECKING, Optional
+
 from sqlalchemy.orm import Session
 
 from chafan_core.app.infra.request_context import RequestContext
 from chafan_core.db.session import SessionLocal
+
+if TYPE_CHECKING:
+    import redis
 
 
 class DataBroker(RequestContext):
@@ -28,11 +32,11 @@ class DataBroker(RequestContext):
 
     # Expose redis/db attributes some call sites still poke at.
     @property
-    def redis(self) -> Optional[redis.Redis]:
+    def redis(self) -> Optional["redis.Redis"]:
         return self._redis
 
     @redis.setter
-    def redis(self, value: Optional[redis.Redis]) -> None:
+    def redis(self, value: Optional["redis.Redis"]) -> None:
         self._redis = value
 
     @property

--- a/chafan_core/app/data_broker.py
+++ b/chafan_core/app/data_broker.py
@@ -1,35 +1,53 @@
+"""Legacy session holder.
+
+Prefer RequestContext (chafan_core.app.infra.request_context). DataBroker remains
+as a thin compatibility wrapper used by CachedLayer and existing call sites.
+use_read_replica is ignored (D6: single Postgres, no replica).
+"""
+
 from typing import Optional
 
 import redis
 from sqlalchemy.orm import Session
 
-from chafan_core.app.common import get_redis_cli
-from chafan_core.db.session import ReadSessionLocal, SessionLocal
+from chafan_core.app.infra.request_context import RequestContext
+from chafan_core.db.session import SessionLocal
 
 
-# Data broker operates after authentication logic and business logic
-# Its main job is to manage cache and data backend sessions.
-class DataBroker(object):
+class DataBroker(RequestContext):
+    """Backward-compatible alias: same lazy db/redis as RequestContext.
+
+    close() still commits (legacy request-end behavior) so existing endpoints
+    keep working until services own transactions.
+    """
+
     def __init__(self, use_read_replica: bool = False) -> None:
-        self.redis: Optional[redis.Redis] = None
-        self.db: Optional[Session] = None
+        super().__init__(principal_id=None)
+        # Kept for signature compatibility; ReadSessionLocal is an alias of SessionLocal.
         self.use_read_replica = use_read_replica
 
-    def get_redis(self) -> redis.Redis:
-        if self.redis is None:
-            self.redis = get_redis_cli()
-        return self.redis
+    # Expose redis/db attributes some call sites still poke at.
+    @property
+    def redis(self) -> Optional[redis.Redis]:
+        return self._redis
+
+    @redis.setter
+    def redis(self, value: Optional[redis.Redis]) -> None:
+        self._redis = value
+
+    @property
+    def db(self) -> Optional[Session]:
+        return self._db
+
+    @db.setter
+    def db(self, value: Optional[Session]) -> None:
+        self._db = value
 
     def get_db(self) -> Session:
-        if self.db is None:
-            if self.use_read_replica:
-                self.db = ReadSessionLocal()
-            else:
-                self.db = SessionLocal()
-        return self.db
+        if self._db is None:
+            # Ignore use_read_replica (D6).
+            self._db = SessionLocal()
+        return self._db
 
     def close(self) -> None:
-        if self.db:
-            if not self.use_read_replica:
-                self.db.commit()
-            self.db.close()
+        self.close_legacy_commit()

--- a/chafan_core/app/infra/__init__.py
+++ b/chafan_core/app/infra/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure helpers (request context, cache utilities, external clients)."""
+
+from chafan_core.app.infra.request_context import RequestContext
+
+__all__ = ["RequestContext"]

--- a/chafan_core/app/infra/__init__.py
+++ b/chafan_core/app/infra/__init__.py
@@ -1,5 +1,6 @@
 """Infrastructure helpers (request context, cache utilities, external clients)."""
 
+# Import RequestContext lazily-safe: no app.crud at module import time.
 from chafan_core.app.infra.request_context import RequestContext
 
 __all__ = ["RequestContext"]

--- a/chafan_core/app/infra/request_context.py
+++ b/chafan_core/app/infra/request_context.py
@@ -5,14 +5,18 @@ This is the target replacement for DataBroker and the rump of CachedLayer
 instead of reaching into CachedLayer for sessions.
 """
 
-from typing import Optional
+from __future__ import annotations
 
-import redis
+from typing import TYPE_CHECKING, Optional
+
 from sqlalchemy.orm import Session
 
-from chafan_core.app import crud, models
 from chafan_core.app.common import get_redis_cli
 from chafan_core.db.session import SessionLocal
+
+if TYPE_CHECKING:
+    import redis
+    from chafan_core.app import models
 
 
 class RequestContext:
@@ -20,13 +24,13 @@ class RequestContext:
 
     def __init__(self, principal_id: Optional[int] = None) -> None:
         self.principal_id = principal_id
-        self._redis: Optional[redis.Redis] = None
+        self._redis: Optional["redis.Redis"] = None
         self._db: Optional[Session] = None
-        self._principal: Optional[models.User] = None
+        self._principal: Optional["models.User"] = None
         # True once a service has explicitly committed the unit of work.
         self._committed: bool = False
 
-    def get_redis(self) -> redis.Redis:
+    def get_redis(self) -> "redis.Redis":
         if self._redis is None:
             self._redis = get_redis_cli()
         return self._redis
@@ -36,14 +40,17 @@ class RequestContext:
             self._db = SessionLocal()
         return self._db
 
-    def try_get_current_user(self) -> Optional[models.User]:
+    def try_get_current_user(self) -> Optional["models.User"]:
         if self.principal_id is None:
             return None
         if self._principal is None:
+            # Lazy import avoids circular import (crud → DataBroker → RequestContext).
+            from chafan_core.app import crud
+
             self._principal = crud.user.get(self.get_db(), id=self.principal_id)
         return self._principal
 
-    def get_current_user(self) -> models.User:
+    def get_current_user(self) -> "models.User":
         user = self.try_get_current_user()
         if user is None:
             raise RuntimeError("No principal on RequestContext")
@@ -54,15 +61,9 @@ class RequestContext:
         self._committed = True
 
     def close(self) -> None:
-        """End of request: commit only if already marked; else roll back.
-
-        During migration, call sites that still rely on DataBroker's implicit
-        commit should use close_legacy_commit() instead.
-        """
+        """End of request: roll back unless a service marked committed."""
         if self._db is not None:
-            if self._committed:
-                pass  # already committed by service
-            else:
+            if not self._committed:
                 self._db.rollback()
             self._db.close()
             self._db = None
@@ -70,7 +71,7 @@ class RequestContext:
     def close_legacy_commit(self) -> None:
         """Match historical DataBroker.close(): commit write session then close.
 
-        Used while endpoints still depend on request-end implicit commits.
+        Used while endpoints still rely on request-end implicit commits.
         Remove once services own all transaction boundaries.
         """
         if self._db is not None:

--- a/chafan_core/app/infra/request_context.py
+++ b/chafan_core/app/infra/request_context.py
@@ -1,0 +1,79 @@
+"""Per-request context: lazy DB + Redis + principal.
+
+This is the target replacement for DataBroker and the rump of CachedLayer
+(principal + sessions). Services and responders should take a RequestContext
+instead of reaching into CachedLayer for sessions.
+"""
+
+from typing import Optional
+
+import redis
+from sqlalchemy.orm import Session
+
+from chafan_core.app import crud, models
+from chafan_core.app.common import get_redis_cli
+from chafan_core.db.session import SessionLocal
+
+
+class RequestContext:
+    """Lazy db + redis + principal for one HTTP request (or background task)."""
+
+    def __init__(self, principal_id: Optional[int] = None) -> None:
+        self.principal_id = principal_id
+        self._redis: Optional[redis.Redis] = None
+        self._db: Optional[Session] = None
+        self._principal: Optional[models.User] = None
+        # True once a service has explicitly committed the unit of work.
+        self._committed: bool = False
+
+    def get_redis(self) -> redis.Redis:
+        if self._redis is None:
+            self._redis = get_redis_cli()
+        return self._redis
+
+    def get_db(self) -> Session:
+        if self._db is None:
+            self._db = SessionLocal()
+        return self._db
+
+    def try_get_current_user(self) -> Optional[models.User]:
+        if self.principal_id is None:
+            return None
+        if self._principal is None:
+            self._principal = crud.user.get(self.get_db(), id=self.principal_id)
+        return self._principal
+
+    def get_current_user(self) -> models.User:
+        user = self.try_get_current_user()
+        if user is None:
+            raise RuntimeError("No principal on RequestContext")
+        return user
+
+    def mark_committed(self) -> None:
+        """Call after an explicit service-level commit."""
+        self._committed = True
+
+    def close(self) -> None:
+        """End of request: commit only if already marked; else roll back.
+
+        During migration, call sites that still rely on DataBroker's implicit
+        commit should use close_legacy_commit() instead.
+        """
+        if self._db is not None:
+            if self._committed:
+                pass  # already committed by service
+            else:
+                self._db.rollback()
+            self._db.close()
+            self._db = None
+
+    def close_legacy_commit(self) -> None:
+        """Match historical DataBroker.close(): commit write session then close.
+
+        Used while endpoints still depend on request-end implicit commits.
+        Remove once services own all transaction boundaries.
+        """
+        if self._db is not None:
+            self._db.commit()
+            self._db.close()
+            self._db = None


### PR DESCRIPTION
Part of the backend re-design stack.

**Stacked PR** — base branch: `dev/step-1-article-materialize`. Review only the incremental diff (this PR = one step of the stack).

Commits in this step:
- Introduce RequestContext; thin DataBroker compatibility (Step 3)
- Fix RequestContext circular import and redis property annotations
- Drop content caches from CachedLayer (Step 3)