### PR TITLE
Fix responder permission stubs (Step 0) (repeat)

### DIFF
--- a/chafan_core/app/responders/answer.py
+++ b/chafan_core/app/responders/answer.py
@@ -1,36 +1,42 @@
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
-
-from chafan_core.app import models, schemas
-from chafan_core.app.schemas.richtext import RichText
-from chafan_core.utils.base import (
-    filter_not_none,
-)
-
-from chafan_core.app import view_counters
-
-
-from chafan_core.app.schemas.answer import AnswerInDBBase
-
+from typing import Optional
 import logging
+
+from chafan_core.app import crud, models, schemas, user_permission, view_counters
+from chafan_core.app.common import OperationType
+from chafan_core.app.schemas.answer import AnswerInDBBase
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.utils.base import filter_not_none
+
 logger = logging.getLogger(__name__)
 
-def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) -> Optional[schemas.Answer]:
+
+def answer_schema_from_orm(
+    cached_layer, answer: models.Answer, principal_id
+) -> Optional[schemas.Answer]:
     db = cached_layer.broker.get_db()
-    #if not can_read_answer(db, answer=answer, principal_id=self.principal_id):
-    #    return None
-    upvoted = (
-        db.query(models.Answer_Upvotes)
-        .filter_by(answer_id=answer.id, voter_id=principal_id, cancelled=False)
-        .first()
-        is not None
-    )
-    # TODO skipped the permission check
-#    comment_writable = user_in_site(
-#        db,
-#        site=answer.site,
-#        user_id=self.principal_id,
-#        op_type=OperationType.WriteSiteComment,
-#    )
+    if not user_permission.answer_read_allowed(db, answer=answer, user_id=principal_id):
+        return None
+
+    upvoted = False
+    comment_writable = False
+    bookmarked = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.Answer_Upvotes)
+            .filter_by(answer_id=answer.id, voter_id=principal_id, cancelled=False)
+            .first()
+            is not None
+        )
+        comment_writable = user_permission.user_in_site(
+            db,
+            site=answer.site,
+            user_id=principal_id,
+            op_type=OperationType.WriteSiteComment,
+        )
+        principal = crud.user.get(db, id=principal_id)
+        if principal is not None:
+            bookmarked = answer in principal.bookmarked_answers
+
     base = AnswerInDBBase.from_orm(answer)
     d = base.dict()
     d["site"] = cached_layer.site_schema_from_orm(answer.site)
@@ -40,21 +46,20 @@ def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) ->
     d["author"] = cached_layer.materializer.preview_of_user(answer.author)
     d["question"] = cached_layer.materializer.preview_of_question(answer.question)
     d["upvoted"] = upvoted
-    d["comment_writable"] = True #comment_writable
+    d["comment_writable"] = comment_writable
     d["bookmark_count"] = answer.bookmarkers.count()
     d["archives_count"] = len(answer.archives)
-    #principal = crud.user.get(db, id=principal_id)
-    #assert principal is not None
-    d["bookmarked"] = True #answer in principal.bookmarked_answers
+    d["bookmarked"] = bookmarked
     d["view_times"] = view_counters.get_viewcount_answer(cached_layer.broker, answer.id)
+
     if answer.is_published:
         body = answer.body
     else:
-        logger.error("FIXME draft read permission not checked")
-        if answer.body_draft:
-            body = answer.body_draft
-        else:
-            body = answer.body
+        # Unpublished drafts: only the author may read (enforced above); serve draft body.
+        if principal_id != answer.author_id:
+            return None
+        body = answer.body_draft if answer.body_draft else answer.body
+
     d["content"] = RichText(
         source=body,
         rendered_text=answer.body_prerendered_text,
@@ -62,4 +67,3 @@ def answer_schema_from_orm(cached_layer, answer: models.Answer, principal_id) ->
     )
     d["suggest_editable"] = answer.body_draft is None
     return schemas.Answer(**d)
-

--- a/chafan_core/app/responders/question.py
+++ b/chafan_core/app/responders/question.py
@@ -1,66 +1,49 @@
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Optional
 import logging
-logger = logging.getLogger(__name__)
 
-from sqlalchemy.orm import Session
+logger = logging.getLogger(__name__)
 
 import chafan_core.app.responders as responders
 from chafan_core.app import models, schemas
-from chafan_core.app.common import OperationType, is_dev
+from chafan_core.app.common import OperationType
 from chafan_core.app.data_broker import DataBroker
 from chafan_core.app.model_utils import (
     get_live_answers_of_question,
 )
-from chafan_core.app.schemas.question import (
-        QuestionInDBBase,
-        QuestionPreviewForSearch
-)
+from chafan_core.app.schemas.question import QuestionInDBBase
 from chafan_core.app.schemas.richtext import RichText
+from chafan_core.app import user_permission, view_counters
 from chafan_core.utils.base import (
     filter_not_none,
     map_,
-    unwrap,
 )
-
-from chafan_core.app import view_counters
-
-def user_in_site(
-    db: Session,
-    *,
-    site: models.Site,
-    user_id: int,
-    op_type: OperationType,
-) -> bool:
-    logger.error("user_in_site is stub TODO")
-    return True
 
 
 def question_schema_from_orm(
-        broker: DataBroker,
-        principal_id,
-        question: models.Question,
-        cached_layer # TODO we should remove this dependency in future 2025-07-23
+    broker: DataBroker,
+    principal_id,
+    question: models.Question,
+    cached_layer,  # TODO we should remove this dependency in future 2025-07-23
 ) -> Optional[schemas.Question]:
-    if not principal_id:
-        logger.error("TODO skipped principle_id check")
-        #return None
-    if not user_in_site(
-        broker.get_db(),
+    db = broker.get_db()
+    if not user_permission.user_in_site(
+        db,
         site=question.site,
         user_id=principal_id,
         op_type=OperationType.ReadSite,
     ):
-        logger.error("TODO skipped principle_id check")
+        return None
 
-    upvoted = (
-        broker.get_db()
-        .query(models.QuestionUpvotes)
-        .filter_by(
-            question_id=question.id, voter_id=principal_id, cancelled=False
+    upvoted = False
+    if principal_id is not None:
+        upvoted = (
+            db.query(models.QuestionUpvotes)
+            .filter_by(
+                question_id=question.id, voter_id=principal_id, cancelled=False
+            )
+            .first()
+            is not None
         )
-        .first()
-        is not None
-    )
     base = QuestionInDBBase.from_orm(question)
     d = base.dict()
     d["site"] = responders.site.site_schema_from_orm(cached_layer, question.site)

--- a/chafan_core/app/user_permission.py
+++ b/chafan_core/app/user_permission.py
@@ -4,11 +4,11 @@ from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models
 from chafan_core.app.common import OperationType
-from chafan_core.app.config import settings
+from chafan_core.app.model_utils import is_live_answer
 from chafan_core.utils.base import ContentVisibility
 
-
 import logging
+
 logger = logging.getLogger(__name__)
 
 # TODO everything about user permission, including if they can create a site (KARMA), invite a user, write an answer, etc, should be moved into this file. 2025-07-08
@@ -19,12 +19,18 @@ def get_active_site_profile(
 ) -> Optional[models.Profile]:
     return crud.profile.get_by_user_and_site(db, owner_id=user_id, site_id=site.id)
 
+
 def user_in_site(
     db: Session,
     site: models.Site,
-    user_id: int,
+    user_id: Optional[int],
     op_type: OperationType,
 ) -> bool:
+    """Site membership / public-flag check for a principal.
+
+    Anonymous principals (user_id is None) only succeed when the site's public
+    flag for the given op_type allows the operation without membership.
+    """
     if op_type == OperationType.ReadSite and site.public_readable:
         return True
     if op_type == OperationType.WriteSiteAnswer and site.public_writable_answer:
@@ -35,14 +41,18 @@ def user_in_site(
         return True
     if op_type == OperationType.WriteSiteComment and site.public_writable_comment:
         return True
+    if user_id is None:
+        return False
     if get_active_site_profile(db, site=site, user_id=user_id) is None:
         return False
     if op_type == OperationType.AddSiteMember and not site.addable_member:
         return False
     return True
 
+
 def article_read_allowed(
-    db: Session, article: models.Article, user_id: Optional[int]) -> bool:
+    db: Session, article: models.Article, user_id: Optional[int]
+) -> bool:
     if article.is_published and article.visibility == ContentVisibility.ANYONE:
         return True
     if article.author_id == user_id and user_id is not None:
@@ -51,8 +61,10 @@ def article_read_allowed(
     logger.info(f"User {user_id} is not allowed to read article {article.id}")
     return False
 
+
 def question_read_allowed(
-    cached_layer, question: models.Question, user_id: Optional[int]) -> bool:
+    cached_layer, question: models.Question, user_id: Optional[int]
+) -> bool:
     if not question.is_hidden:
         return True
     if user_id is not None and user_id == question.author_id:
@@ -63,3 +75,24 @@ def question_read_allowed(
     return False
 
 
+def answer_read_allowed(
+    db: Session, answer: models.Answer, user_id: Optional[int]
+) -> bool:
+    """Binary read gate for answers: allowed → full schema; denied → no payload.
+
+    Matches the prior materialize split: authors always; live answers for site
+    members / public-read; anonymous additionally requires ANYONE visibility.
+    """
+    if answer.is_deleted:
+        return False
+    if user_id is not None and user_id == answer.author_id:
+        return True
+    if not is_live_answer(answer):
+        return False
+    if user_id is None:
+        if answer.visibility != ContentVisibility.ANYONE:
+            return False
+        return bool(answer.site.public_readable)
+    return user_in_site(
+        db, site=answer.site, user_id=user_id, op_type=OperationType.ReadSite
+    )


### PR DESCRIPTION
Route question site membership through user_permission.user_in_site instead of the always-True local stub. Restore answer read gating, comment_writable, bookmarked, and author-only draft body access. Anonymous principals are supported for public-read sites; denied reads return None rather than a partial payload.

Apply https://github.com/chafan-dev/chafan-core/pull/118 again