### PR TITLE
smoke: add authz-negative scenario + tighten notification/feed assertions

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,9 +1,11 @@
 name: E2E smoke (bootstrap)
 
 # Bootstrap-mode end-to-end smoke test: seed a fresh DB, boot a live
-# uvicorn server + dramatiq worker, and drive the real HTTP API through the
-# smoke suite (chafan-core/smoke). This is the CI-safe mode — it invents its
-# own users/site/data and needs no secrets.
+# uvicorn server, and drive the real HTTP API through the smoke suite
+# (chafan-core/smoke). Post-response fan-out (feed, notifications) runs in
+# process via FastAPI BackgroundTasks, so no separate worker is needed. This
+# is the CI-safe mode — it invents its own users/site/data and needs no
+# secrets.
 #
 # The "real world" mode of the suite (hitting api.cha.fan with real accounts)
 # is intentionally NOT run here; it is a manual, credentialed operation.

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -3,7 +3,9 @@
 End-to-end smoke test that drives the real HTTP API and exercises every
 critical read/write path: auth, questions, answers, comments, submissions,
 articles, the follow graph, activity-feed fan-out, notifications, and private
-messages. Exit code 0 = the backend is sane.
+messages. It also asserts the negative paths (`s13_authz`): anonymous writes
+and non-author edits/deletes are rejected with the expected status. Exit code
+0 = the backend is sane.
 
 The suite reads `config.json` (git-ignored) for the target endpoint and two
 member accounts, then runs the scenarios in `scenarios/` fail-fast.

--- a/smoke/client.py
+++ b/smoke/client.py
@@ -4,10 +4,11 @@ One ApiClient per account. Holds the JWT in memory for the run.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import pathlib
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 import requests
 
@@ -15,7 +16,9 @@ DEBUG = bool(os.environ.get("DEBUG"))
 
 
 class ApiError(RuntimeError):
-    pass
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def load_config() -> dict:
@@ -87,7 +90,8 @@ class ApiClient:
         if len(body) > 800:
             body = body[:800] + "... [truncated]"
         raise ApiError(
-            f"{method} {path} → {resp.status_code}\n  body: {body}"
+            f"{method} {path} → {resp.status_code}\n  body: {body}",
+            status_code=resp.status_code,
         )
 
     def _log(self, method: str, path: str, status: int) -> None:
@@ -168,6 +172,30 @@ class ApiClient:
         self.full_name = me.get("full_name")
 
 
+@contextlib.contextmanager
+def expect_error(*statuses: int) -> Iterator[None]:
+    """Assert the wrapped API call raises ApiError with one of ``statuses``.
+
+    Used by the negative scenarios: a permission-denied or unauthenticated
+    call *must* fail, and must fail with the specific status we expect (not
+    e.g. a 500). A call that unexpectedly succeeds is itself a regression.
+
+        with expect_error(401):
+            anon.post("/api/v1/questions/", {...})
+    """
+    try:
+        yield
+    except ApiError as e:
+        if statuses and e.status_code not in statuses:
+            raise AssertionError(
+                f"expected HTTP {list(statuses)}, got {e.status_code}: {e}"
+            ) from None
+        return
+    raise AssertionError(
+        f"expected the call to fail with HTTP {list(statuses)}, but it succeeded"
+    )
+
+
 def richtext(body: str) -> dict:
     """Build a RichText payload the backend accepts."""
     return {"source": body, "editor": "wysiwyg", "rendered_text": body}
@@ -176,6 +204,18 @@ def richtext(body: str) -> dict:
 def ok(prefix: str, label: str, extra: str = "") -> None:
     """Print an OK line, fixed-width for readability."""
     line = f"[{prefix:<12}] {label:<34} OK"
+    if extra:
+        line += f"   {extra}"
+    print(line)
+
+
+def note(prefix: str, label: str, status: str, extra: str = "") -> None:
+    """Print a non-OK status line (e.g. SKIP / XFAIL) in the same format.
+
+    Distinct from ``ok()`` so a known-bug branch never masquerades as a pass:
+    the operator sees the literal status word, not "OK".
+    """
+    line = f"[{prefix:<12}] {label:<34} {status}"
     if extra:
         line += f"   {extra}"
     print(line)

--- a/smoke/run_all.py
+++ b/smoke/run_all.py
@@ -23,11 +23,14 @@ from scenarios import (
     s10_feed_fanout,
     s11_notifications,
     s12_messages,
+    s13_authz,
     s08_delete,
 )
 
 # Order matches SMOKE_TEST_PLAN.md § "Scenario order note".
-# s08_delete runs absolutely last so s11 still has A's question/answer.
+# s13_authz runs before s08_delete: it needs A's answer to exist (and asserts
+# the rejected delete leaves it intact). s08_delete runs absolutely last so
+# s11 still has A's question/answer.
 SCENARIOS = [
     s01_auth,
     s02_read_only,
@@ -40,6 +43,7 @@ SCENARIOS = [
     s10_feed_fanout,
     s11_notifications,
     s12_messages,
+    s13_authz,
     s08_delete,
 ]
 

--- a/smoke/scenarios/s02_read_only.py
+++ b/smoke/scenarios/s02_read_only.py
@@ -24,9 +24,9 @@ def run(state: dict) -> None:
 
     topics = a.anonymous_get("/api/v1/category-topics/")
     assert isinstance(topics, list), (
-        f"/login/category-topics/ expected list, got: {type(topics).__name__}"
+        f"/category-topics/ expected list, got: {type(topics).__name__}"
     )
-    ok(TAG, "GET /login/category-topics/", f"n={len(topics)}")
+    ok(TAG, "GET /category-topics/", f"n={len(topics)}")
 
 
 if __name__ == "__main__":

--- a/smoke/scenarios/s10_feed_fanout.py
+++ b/smoke/scenarios/s10_feed_fanout.py
@@ -16,7 +16,7 @@ import json
 import time
 import uuid as uuidlib
 
-from client import ok
+from client import note, ok
 from poll import wait_for
 
 TAG = "s10_feed"
@@ -64,14 +64,21 @@ def run(state: dict) -> None:
     question_uuid_negative, _ = _post_fresh_question(b, cfg["site_uuid"])
     ok(TAG, "B creates question (negative)", f"uuid={question_uuid_negative}")
 
-    # Known bug: unfollow does not prune future fan-out. Skipping negative
-    # check until the activity refactor lands.
-    # TODO: re-enable once the feed fan-out bug is fixed.
+    # Known bug: unfollow does not prune already-scheduled fan-out, so the
+    # negative case is an *expected failure* rather than a pass. Emit XFAIL
+    # (not OK) when the leak is present so it never masquerades as a green
+    # check; emit a genuine OK if the leak is gone (bug fixed).
+    # TODO: turn XFAIL into a hard assertion once the feed fan-out bug is fixed.
     time.sleep(timeout)
     if _feed_contains(a, question_uuid_negative):
-        ok(TAG, "GET /activities/ (negative)", "SKIPPED (known bug: unfollow does not prune fan-out)")
+        note(
+            TAG,
+            "GET /activities/ (negative)",
+            "XFAIL",
+            "known bug: unfollow does not prune fan-out",
+        )
     else:
-        ok(TAG, "GET /activities/ (negative)", f"waited={timeout:.1f}s")
+        ok(TAG, "GET /activities/ (negative)", f"waited={timeout:.1f}s (no leak)")
 
 
 if __name__ == "__main__":

--- a/smoke/scenarios/s11_notifications.py
+++ b/smoke/scenarios/s11_notifications.py
@@ -12,7 +12,6 @@ Both sub-flows are polled because the fan-out is post-response (BackgroundTasks)
 """
 from __future__ import annotations
 
-import json
 import uuid as uuidlib
 
 from client import ok, richtext
@@ -21,9 +20,27 @@ from poll import wait_for
 TAG = "s11_notify"
 
 
-def _unread_contains(client, needle: str) -> bool:
-    resp = client.get("/api/v1/notifications/unread/")
-    return needle in json.dumps(resp)
+def _find_notification(client, *, verb: str, uuid_path: list[str], expected_uuid: str):
+    """Return the unread notification whose event matches, else None.
+
+    Stronger than a substring match on the serialized blob: the event must
+    have the right ``verb`` *and* the uuid at ``uuid_path`` (e.g.
+    ``["answer", "uuid"]``) must equal ``expected_uuid``. This catches a
+    malformed event that merely happens to embed the uuid somewhere.
+    """
+    for notif in client.get("/api/v1/notifications/unread/"):
+        event = notif.get("event") or {}
+        if event.get("verb") != verb:
+            continue
+        node = event
+        for key in uuid_path:
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = node.get(key)
+        if node == expected_uuid:
+            return notif
+    return None
 
 
 def run(state: dict) -> None:
@@ -50,12 +67,21 @@ def run(state: dict) -> None:
     state["b_answer_uuid"] = b_answer_uuid
     ok(TAG, "B answers A's question", f"uuid={b_answer_uuid}")
 
-    _, elapsed = wait_for(
-        lambda: _unread_contains(a, b_answer_uuid),
+    notif, elapsed = wait_for(
+        lambda: _find_notification(
+            a, verb="answer_question", uuid_path=["answer", "uuid"],
+            expected_uuid=b_answer_uuid,
+        ),
         timeout=timeout,
-        desc=f"A's notifications never referenced B's answer {b_answer_uuid}",
+        desc=(
+            f"A had no 'answer_question' notification referencing B's answer "
+            f"{b_answer_uuid}"
+        ),
     )
-    ok(TAG, "A polls /notifications/unread/", f"elapsed={elapsed:.1f}s")
+    assert notif["event"]["subject"]["uuid"] == b.uuid, (
+        f"reply notification actor is not B: {notif['event'].get('subject')!r}"
+    )
+    ok(TAG, "A polls /notifications/unread/", f"elapsed={elapsed:.1f}s verb=answer_question")
 
     # ---- Sub-flow B: mention notification -------------------------------
     mention_body = f"smoke-test mention of @{b.handle}"
@@ -70,15 +96,21 @@ def run(state: dict) -> None:
     mention_comment_uuid = created["uuid"]
     ok(TAG, "A comments with mention", f"uuid={mention_comment_uuid}")
 
-    _, elapsed = wait_for(
-        lambda: _unread_contains(b, mention_comment_uuid),
+    notif, elapsed = wait_for(
+        lambda: _find_notification(
+            b, verb="mentioned_in_comment", uuid_path=["comment", "uuid"],
+            expected_uuid=mention_comment_uuid,
+        ),
         timeout=timeout,
         desc=(
-            f"B's notifications never referenced mention comment "
+            f"B had no 'mentioned_in_comment' notification referencing comment "
             f"{mention_comment_uuid}"
         ),
     )
-    ok(TAG, "B polls /notifications/unread/", f"elapsed={elapsed:.1f}s")
+    assert notif["event"]["subject"]["uuid"] == a.uuid, (
+        f"mention notification actor is not A: {notif['event'].get('subject')!r}"
+    )
+    ok(TAG, "B polls /notifications/unread/", f"elapsed={elapsed:.1f}s verb=mentioned_in_comment")
 
 
 if __name__ == "__main__":

--- a/smoke/scenarios/s11_notifications.py
+++ b/smoke/scenarios/s11_notifications.py
@@ -27,12 +27,16 @@ def _find_notification(client, *, verb: str, uuid_path: list[str], expected_uuid
     have the right ``verb`` *and* the uuid at ``uuid_path`` (e.g.
     ``["answer", "uuid"]``) must equal ``expected_uuid``. This catches a
     malformed event that merely happens to embed the uuid somewhere.
+
+    The serialized ``event`` is ``{"created_at", "content": {...}}`` — verb
+    and the content preview both live under ``event.content`` (see the
+    ``Event`` schema), so ``uuid_path`` is walked from there.
     """
     for notif in client.get("/api/v1/notifications/unread/"):
-        event = notif.get("event") or {}
-        if event.get("verb") != verb:
+        content = (notif.get("event") or {}).get("content") or {}
+        if content.get("verb") != verb:
             continue
-        node = event
+        node = content
         for key in uuid_path:
             if not isinstance(node, dict):
                 node = None
@@ -78,8 +82,8 @@ def run(state: dict) -> None:
             f"{b_answer_uuid}"
         ),
     )
-    assert notif["event"]["subject"]["uuid"] == b.uuid, (
-        f"reply notification actor is not B: {notif['event'].get('subject')!r}"
+    assert notif["event"]["content"]["subject"]["uuid"] == b.uuid, (
+        f"reply notification actor is not B: {notif['event']['content'].get('subject')!r}"
     )
     ok(TAG, "A polls /notifications/unread/", f"elapsed={elapsed:.1f}s verb=answer_question")
 
@@ -107,8 +111,8 @@ def run(state: dict) -> None:
             f"{mention_comment_uuid}"
         ),
     )
-    assert notif["event"]["subject"]["uuid"] == a.uuid, (
-        f"mention notification actor is not A: {notif['event'].get('subject')!r}"
+    assert notif["event"]["content"]["subject"]["uuid"] == a.uuid, (
+        f"mention notification actor is not A: {notif['event']['content'].get('subject')!r}"
     )
     ok(TAG, "B polls /notifications/unread/", f"elapsed={elapsed:.1f}s verb=mentioned_in_comment")
 

--- a/smoke/scenarios/s13_authz.py
+++ b/smoke/scenarios/s13_authz.py
@@ -1,0 +1,94 @@
+"""s13 — authorization / negative paths.
+
+Every other scenario is a happy path. This one asserts the backend *rejects*
+what it should, which catches a whole class of authz regressions cheaply:
+
+  1. Anonymous (no token) writes are refused — login-gated endpoints return
+     401 when the Authorization header is absent (OAuth2 auto_error).
+  2. Anonymous access to a login-gated read (/notifications/unread/) is 401.
+  3. A non-author cannot edit someone else's answer — author-only, 400.
+  4. A non-author cannot delete someone else's answer — author-only, 400.
+
+Note on why we target *answers*, not questions: in this site both A and B are
+members, and question editing is wiki-style (any site member may edit), so
+"B edits A's question" is *allowed* by design and would be a bad negative.
+Answer edit/delete is strictly author-only, so B acting on A's answer is a
+true permission denial.
+
+Runs before s08_delete so A's answer still exists; the rejected delete in (4)
+leaves it intact.
+"""
+from __future__ import annotations
+
+import uuid as uuidlib
+
+from client import ApiClient, expect_error, ok, richtext
+
+TAG = "s13_authz"
+
+
+def run(state: dict) -> None:
+    a = state["a"]
+    b = state["b"]
+    cfg = state["cfg"]
+    question_uuid = state["question_uuid"]
+    answer_uuid = state["answer_uuid"]
+
+    # Fresh client with no token → sends no Authorization header.
+    anon = ApiClient(cfg["api_base"], "anon")
+
+    # ---- 1. anonymous write is refused (401) ---------------------------
+    with expect_error(401):
+        anon.post(
+            "/api/v1/questions/",
+            {"site_uuid": cfg["site_uuid"], "title": "should-never-persist"},
+        )
+    ok(TAG, "anon POST /questions/ → 401")
+
+    with expect_error(401):
+        anon.post(
+            "/api/v1/answers/",
+            {
+                "question_uuid": question_uuid,
+                "content": richtext("should-never-persist"),
+                "is_published": True,
+                "visibility": "anyone",
+                "writing_session_uuid": str(uuidlib.uuid4()),
+            },
+        )
+    ok(TAG, "anon POST /answers/ → 401")
+
+    # ---- 2. anonymous login-gated read is refused (401) ----------------
+    with expect_error(401):
+        anon.get("/api/v1/notifications/unread/")
+    ok(TAG, "anon GET /notifications/unread/ → 401")
+
+    # ---- 3. non-author cannot edit A's answer (400) --------------------
+    with expect_error(400):
+        b.put(
+            f"/api/v1/answers/{answer_uuid}",
+            {
+                "updated_content": richtext("B should not be able to write this"),
+                "is_draft": False,
+                "visibility": "anyone",
+            },
+        )
+    ok(TAG, "B PUT A's answer → 400 (author-only)")
+
+    # ---- 4. non-author cannot delete A's answer (400) ------------------
+    # Rejected, so A's answer survives for s08_delete.
+    with expect_error(400):
+        b.delete(f"/api/v1/answers/{answer_uuid}")
+    ok(TAG, "B DELETE A's answer → 400 (author-only)")
+
+    # The answer must still be there for s08.
+    still_there = a.get(f"/api/v1/answers/{answer_uuid}")
+    assert still_there.get("uuid") == answer_uuid, (
+        f"A's answer vanished after rejected delete: {still_there!r}"
+    )
+    ok(TAG, "A's answer still intact")
+
+
+if __name__ == "__main__":
+    from scenarios import bootstrap
+    run(bootstrap.build_state())


### PR DESCRIPTION
## What

Adds negative-path coverage to the E2E smoke suite and strengthens two weak assertions.

### New scenario — `s13_authz`
The suite was entirely happy-path. This asserts the backend **rejects** what it should:

| Case | Expected |
|---|---|
| anon `POST /questions/` | 401 |
| anon `POST /answers/` | 401 |
| anon `GET /notifications/unread/` | 401 |
| B edits A's answer | 400 (author-only) |
| B deletes A's answer | 400, then confirms the answer survives |

It targets **answers**, not questions, on purpose: question editing is wiki-style for site members (allowed by design), whereas answer edit/delete is strictly author-only — so that's the correct cross-account denial. Runs before `s08_delete` so A's answer still exists. Every status code was verified against the backend source (`user_permission.py`, `services/answers.py`, `api/deps.py`), not guessed.

### Tighter assertions
- **`s11` notifications** — replaced `uuid in json.dumps(resp)` with a structural check: `event.verb` (`answer_question` / `mentioned_in_comment`), the nested content uuid, and the actor (`event.subject.uuid`) must all match. Catches a malformed event that merely embeds the uuid somewhere.
- **`s10` feed fan-out** — the known unfollow-doesn't-prune leak now reports a distinct **`XFAIL`** status instead of printing `OK`, so a known bug never reads as a green pass. A genuine `OK` prints only if the leak is actually gone.

### Supporting infra (`client.py`)
- `ApiError` now carries `status_code`
- new `expect_error(*statuses)` context manager (fails if the call succeeds *or* returns the wrong code)
- new `note()` helper for non-OK status lines

### Doc fixes
- Dropped the stale "dramatiq worker" claim from the CI workflow — fan-out is in-process FastAPI `BackgroundTasks`, no separate worker is launched.
- Fixed the `s02` endpoint label (`/login/category-topics/` → `/category-topics/`).
- README coverage line updated.

## Testing
Static verification: parse + byte-compile clean, all modules import, `expect_error` behavior unit-checked (matching status passes / mismatch fails / unexpected success fails), scenario order asserted (`s13` before `s08`, `s08` last).

Not yet run end-to-end against a live server (needs Postgres + Redis in the nix devShell via `./scripts/e2e/run_e2e_smoke.sh`) — the bootstrap CI job on this PR exercises that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)