### PR TITLE
ci: set lock_timeout so lock contention fails fast instead of hanging 6h

### DIFF
--- a/chafan_core/app/api/api_v1/endpoints/login.py
+++ b/chafan_core/app/api/api_v1/endpoints/login.py
@@ -23,7 +23,6 @@ from chafan_core.app.common import (
     check_email,
     client_ip,
     get_redis_cli,
-    is_dev,
 )
 from chafan_core.app.security import (
     check_token_validity_impl,
@@ -456,9 +455,8 @@ def claim_welcome_test_rewards(
     form_response = crud.form_response.get(db, id=id)
     if form_response is None:
         raise HTTPException_(status_code=400, detail="Invalid form response id.")
-    if not is_dev():
-        if form_response.form.uuid != settings.WELCOME_TEST_FORM_UUID:
-            raise HTTPException_(status_code=400, detail="Wrong form.")
+    if form_response.form.uuid != settings.WELCOME_TEST_FORM_UUID:
+        raise HTTPException_(status_code=400, detail="Wrong form.")
     if form_response.response_author_id != current_user.id:
         raise HTTPException_(status_code=400, detail="Unauthorized.")
     scores = compute_score_of_form_response(form_response)

--- a/chafan_core/app/api/api_v1/endpoints/upload.py
+++ b/chafan_core/app/api/api_v1/endpoints/upload.py
@@ -9,7 +9,7 @@ from pydantic.tools import parse_obj_as
 from chafan_core.app import schemas
 from chafan_core.app.api import deps
 from chafan_core.app.aws import get_s3_client
-from chafan_core.app.common import is_dev, valid_content_length
+from chafan_core.app.common import valid_content_length
 from chafan_core.app.config import settings
 from chafan_core.utils.base import HTTPException_, unwrap
 
@@ -22,15 +22,14 @@ def upload_image(
     current_user_id: Optional[int] = Depends(deps.try_get_current_user_id),
     file_size: int = Depends(valid_content_length),
 ) -> Any:
-    if is_dev():
+    if settings.AWS_CLOUDFRONT_HOST is None:
+        # No object store configured (e.g. local dev): return a placeholder.
         return schemas.UploadedImage(url="https://picsum.photos/200/300")
-    else:
-        if not current_user_id:
-            raise HTTPException_(
-                status_code=400,
-                detail="Upload requires login.",
-            )
-    assert settings.AWS_CLOUDFRONT_HOST is not None
+    if not current_user_id:
+        raise HTTPException_(
+            status_code=400,
+            detail="Upload requires login.",
+        )
     s3 = get_s3_client()
     tmpfile_name = None
     h = hashlib.sha256()
@@ -60,7 +59,8 @@ def upload_files_from_vditor(
     current_user_id: Optional[int] = Depends(deps.try_get_current_user_id),
     file_size: int = Depends(valid_content_length),
 ) -> Any:
-    if is_dev():
+    if settings.AWS_CLOUDFRONT_HOST is None:
+        # No object store configured (e.g. local dev): return a placeholder.
         return schemas.msg.UploadResults(
             data=schemas.msg.UploadResultData(
                 succMap={
@@ -70,13 +70,11 @@ def upload_files_from_vditor(
                 }
             )
         )
-    else:
-        if not current_user_id:
-            raise HTTPException_(
-                status_code=400,
-                detail="Upload requires login.",
-            )
-    assert settings.AWS_CLOUDFRONT_HOST is not None
+    if not current_user_id:
+        raise HTTPException_(
+            status_code=400,
+            detail="Upload requires login.",
+        )
     s3 = get_s3_client()
     succMap: Dict[str, AnyHttpUrl] = {}
     for file in files:

--- a/chafan_core/app/crud/crud_answer.py
+++ b/chafan_core/app/crud/crud_answer.py
@@ -5,7 +5,6 @@ from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
 from chafan_core.app import crud
-from chafan_core.app.common import is_dev
 from chafan_core.app.crud.base import CRUDBase
 from chafan_core.app.crud.crud_activity import upvote_answer_activity
 from chafan_core.app.models.answer import Answer, Answer_Upvotes
@@ -94,11 +93,10 @@ class CRUDAnswer(CRUDBase[Answer, AnswerCreate, AnswerUpdate]):
         return db_obj
 
     def search(self, db: Session, *, q: str) -> List[Answer]:
-        if is_dev():
-            return self.get_all_published(db)
         ids = do_search("answer", query=q)
-        if not ids:
-            return []
+        if ids is None:
+            # Search index unavailable (e.g. local dev): fall back to listing all.
+            return self.get_all_published(db)
         ret = []
         for id in ids:
             answer = self.get_one_as_search_result(db, id=id)

--- a/chafan_core/app/crud/crud_question.py
+++ b/chafan_core/app/crud/crud_question.py
@@ -5,7 +5,6 @@ from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models
-from chafan_core.app.common import is_dev
 from chafan_core.app.crud.base import CRUDBase
 from chafan_core.app.crud.crud_activity import upvote_question_activity
 from chafan_core.app.models.question import Question, QuestionUpvotes
@@ -51,11 +50,10 @@ class CRUDQuestion(CRUDBase[Question, QuestionCreate, QuestionUpdate]):
         return db_obj
 
     def search(self, db: Session, *, q: str) -> List[Question]:
-        if is_dev():
-            return self.get_all_valid(db)
         ids = do_search("question", query=q)
-        if not ids:
-            return []
+        if ids is None:
+            # Search index unavailable (e.g. local dev): fall back to listing all.
+            return self.get_all_valid(db)
         ret = []
         for id in ids:
             question = self.get(db, id=id)

--- a/chafan_core/app/email_utils.py
+++ b/chafan_core/app/email_utils.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 #from emails.template import JinjaTemplate  # type: ignore
 
 from chafan_core.app import schemas
-from chafan_core.app.common import from_now, is_dev, render_notif_content
+from chafan_core.app.common import from_now, render_notif_content
 from chafan_core.app.config import settings
 
 # TODO this file should be moved into chafan_core/app/email_util

--- a/chafan_core/app/security.py
+++ b/chafan_core/app/security.py
@@ -15,7 +15,6 @@ from chafan_core.app.common import (
     check_email,
     client_ip,
     get_redis_cli,
-    is_dev,
 )
 
 import logging

--- a/chafan_core/app/services/discovery.py
+++ b/chafan_core/app/services/discovery.py
@@ -11,7 +11,7 @@ from pydantic import TypeAdapter
 from sqlalchemy.orm.session import Session
 
 from chafan_core.app import crud, models, schemas
-from chafan_core.app.common import get_redis_cli, is_dev
+from chafan_core.app.common import get_redis_cli
 from chafan_core.app.model_utils import get_live_answers_of_question
 from chafan_core.app.recs import indexed_layer
 from chafan_core.app.infra.runtime import execute_with_db
@@ -32,10 +32,9 @@ def pinned_questions(ctx) -> List[schemas.QuestionPreview]:
     def runnable(db: Session) -> List[schemas.QuestionPreview]:
         questions = crud.question.get_placed_at_home(db)
         data = filter_not_none([mat.preview_of_question(q) for q in questions])
-        if not is_dev():
-            redis.set(
-                key, json.dumps(jsonable_encoder(data)), ex=datetime.timedelta(hours=12)
-            )
+        redis.set(
+            key, json.dumps(jsonable_encoder(data)), ex=datetime.timedelta(hours=12)
+        )
         return data
 
     return execute_with_db(SessionLocal(), runnable)
@@ -79,10 +78,9 @@ def pending_questions(ctx) -> List[schemas.QuestionPreview]:
     if value is not None:
         return TypeAdapter(List[schemas.QuestionPreview]).validate_json(value)
     data = _get_pending_questions(ctx)
-    if not is_dev():
-        redis.set(
-            key, json.dumps(jsonable_encoder(data)), ex=datetime.timedelta(hours=24)
-        )
+    redis.set(
+        key, json.dumps(jsonable_encoder(data)), ex=datetime.timedelta(hours=24)
+    )
     return data
 
 

--- a/chafan_core/app/services/webhook_delivery.py
+++ b/chafan_core/app/services/webhook_delivery.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Literal, NamedTuple, Union
 
 import requests
@@ -7,10 +8,11 @@ from pydantic.main import BaseModel
 from pydantic.tools import parse_obj_as
 
 from chafan_core.app import models
-from chafan_core.app.common import is_dev
 from chafan_core.app.schemas import AnswerPreview, QuestionPreview
 from chafan_core.app.schemas.submission import Submission
 from chafan_core.app.schemas.webhook import WebhookEventSpec, WebhookSiteEvent
+
+logger = logging.getLogger(__name__)
 
 
 class SiteNewAnswerEvent(NamedTuple):
@@ -57,8 +59,7 @@ def _post_webhook(webhook: models.Webhook, webhook_event: WebhookEvent) -> None:
             },
             timeout=5,
         )
-        if is_dev():
-            print("Response: " + r.text)
+        logger.debug("webhook response: %s", r.text)
     except Exception as e:
         sentry_sdk.capture_exception(e)
 

--- a/chafan_core/tests/app/api/api_v1/test_users.py
+++ b/chafan_core/tests/app/api/api_v1/test_users.py
@@ -85,6 +85,9 @@ def test_create_user_existing_username(client: TestClient, db: Session) -> None:
         email=username, password=password, handle=random_short_lower_string()
     )
     crud.user.create(db, obj_in=user_in)
+    # crud no longer commits; the API call below runs on a different session, so
+    # this insert must be committed or its unique-index lock blocks it forever.
+    db.commit()
     r = get_open_user_account_response(
         client, username, password.get_secret_value(), invitation_uuid
     )

--- a/chafan_core/tests/conftest.py
+++ b/chafan_core/tests/conftest.py
@@ -196,6 +196,8 @@ def ensure_user_has_coins(db: Session, user_id: int, coins: int = 100) -> None:
 
     if user.remaining_coins < coins:
         crud.user.update(db, db_obj=user, obj_in={"remaining_coins": coins})
+        # crud flushes only; commit so API requests (separate sessions) see the coins.
+        db.commit()
 
 
 # =============================================================================

--- a/chafan_core/tests/utils/user.py
+++ b/chafan_core/tests/utils/user.py
@@ -38,6 +38,8 @@ def create_random_user(db: Session) -> User:
         email=email, password=password, handle=random_short_lower_string()
     )
     user = crud.user.create(db=db, obj_in=user_in)
+    # crud flushes only; commit so the row is visible to other sessions (API calls).
+    db.commit()
     return user
 
 
@@ -61,5 +63,8 @@ def authentication_token_from_email(
     else:
         user_in_update = UserUpdate(password=password)
         user = crud.user.update(db, db_obj=user, obj_in=user_in_update)
+    # crud flushes only; the login below runs on a different session, so the new
+    # user / updated password must be committed to be visible to it.
+    db.commit()
 
     return user_authentication_headers(client=client, email=email, password=password)

--- a/env.ci
+++ b/env.ci
@@ -15,3 +15,9 @@ CREATE_SITE_FORCE_NEED_APPROVAL=False
 ENV=dev
 DEBUG_BYPASS_REDIS_VERIFICATION_CODE=magic_dev
 PGPASSWORD=postgres
+# CI guard: fail fast on lock contention instead of blocking forever.
+# A test that seeds data via crud (flush-only) without committing leaves its
+# transaction open; a later API call on another session then waits on that
+# row lock indefinitely, burning the full 6h job timeout. libpq passes this
+# to every psycopg2 connection, so such a test errors in 30s instead.
+PGOPTIONS="-c lock_timeout=30s"


### PR DESCRIPTION
> **Stacked on #153** (base is `remove-is-dev-branching`, which carries the test fix this guard protects). GitHub retargets this to `main` automatically once #153 merges.

## Why

PR #153 diagnosed an `api-tests` job that hung to GitHub's **6-hour ceiling** on three separate runs. The cause was a row-lock wait with no timeout: a test seeds data via crud (flush-only since the crud demotion) without committing, leaving the fixture's transaction open; a later API call on another session then waits on that lock forever.

The bug itself is fixed in #153. This adds the guard, because the *failure mode* is the expensive part — six hours of CI with no output, no failing test name, nothing to go on. `CRUDBase` still has 27 inheritors, so as the crud demotion continues this class of bug can recur.

## What

```diff
+PGOPTIONS="-c lock_timeout=30s"
```

libpq passes `PGOPTIONS` to every psycopg2 connection, so this covers `alembic`, `initial_data.py` and `pytest` without touching application code. Scoped to `env.ci` — **production is unaffected**.

## Verification

Removed the `test_users.py` commit fix and re-ran. Instead of hanging:

```
psycopg2.errors.LockNotAvailable: canceling statement due to lock timeout
FAILED chafan_core/tests/app/api/api_v1/test_users.py::test_create_user_existing_username
1 failed, 3 passed in 31.78s
```

**6h with no diagnostic → 32s naming the exact test.**

With the fix in place the guard never fires: api suite green in **8.53s** (74 passed, 9 skipped). 30s is far above the whole suite's runtime, so it cannot cause flaky failures on legitimately slow queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
