### PR TITLE
Finish D2: remove the last visitor/user dual code paths

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -62,7 +62,7 @@ jobs:
         set +a
         nix develop --command bash -c "
           set -e
-          PYTHONPATH=\$PWD pytest --cov=chafan_core/app --cov-report=xml:coverage-unit.xml chafan_core/tests/app/test_search.py chafan_core/tests/app/test_feed.py -v
+          PYTHONPATH=\$PWD pytest --cov=chafan_core/app --cov-report=xml:coverage-unit.xml chafan_core/tests/app/test_search.py chafan_core/tests/app/test_feed.py chafan_core/tests/app/test_user_permission.py -v
         "
 
     - name: Upload coverage

--- a/chafan_core/app/infra/principal_view.py
+++ b/chafan_core/app/infra/principal_view.py
@@ -78,11 +78,6 @@ class PrincipalView:
 
         return responders.question.preview_of_question(self, question)
 
-    def preview_of_question_for_visitor(
-        self, question: "models.Question"
-    ) -> Optional["schemas.QuestionPreview"]:
-        return self.preview_of_question(question)
-
     def get_answer_preview_base(
         self, answer: "models.Answer"
     ) -> "schemas.answer.AnswerPreviewBase":
@@ -96,11 +91,6 @@ class PrincipalView:
         from chafan_core.app.responders import answer as answer_responder
 
         return answer_responder.preview_of_answer(self, answer)
-
-    def preview_of_answer_for_visitor(
-        self, answer: "models.Answer"
-    ) -> Optional["schemas.AnswerPreview"]:
-        return self.preview_of_answer(answer)
 
     def preview_of_article(
         self, article: "models.Article"
@@ -185,11 +175,6 @@ class PrincipalView:
         import chafan_core.app.responders as responders
 
         return responders.submission.submission_schema_from_orm(self, submission)
-
-    def submission_for_visitor_schema_from_orm(
-        self, submission: "models.Submission"
-    ) -> Optional["schemas.Submission"]:
-        return self.submission_schema_from_orm(submission)
 
     def notification_schema_from_orm(
         self, notification: "models.Notification"

--- a/chafan_core/app/responders/article.py
+++ b/chafan_core/app/responders/article.py
@@ -2,37 +2,18 @@ from typing import Optional
 import logging
 
 from chafan_core.app import crud, models, schemas, user_permission, view_counters
-from chafan_core.app.model_utils import is_live_article
 from chafan_core.app.responders._util import get_db, shaper
 from chafan_core.app.schemas.article import ArticleInDB
 from chafan_core.app.schemas.richtext import RichText
-from chafan_core.utils.base import ContentVisibility, filter_not_none
+from chafan_core.utils.base import filter_not_none
 
 logger = logging.getLogger(__name__)
 
 
-def can_read_article(*, article: models.Article, principal_id: int) -> bool:
-    if article.is_deleted:
-        return False
-    if principal_id == article.author_id:
-        return True
-    return is_live_article(article)
-
-
-def visitor_can_read_article(*, article: models.Article) -> bool:
-    if not is_live_article(article):
-        return False
-    return article.visibility == ContentVisibility.ANYONE
-
-
 def preview_of_article(ctx, article: models.Article) -> Optional[schemas.ArticlePreview]:
     principal_id = ctx.principal_id
-    if principal_id:
-        if not can_read_article(article=article, principal_id=principal_id):
-            return None
-    else:
-        if not visitor_can_read_article(article=article):
-            return None
+    if not user_permission.article_preview_read_allowed(article, principal_id):
+        return None
     mat = shaper(ctx)
     return schemas.ArticlePreview(
         uuid=article.uuid,

--- a/chafan_core/app/services/webhook_delivery.py
+++ b/chafan_core/app/services/webhook_delivery.py
@@ -107,9 +107,7 @@ def call_webhook(
             isinstance(event_spec_content, WebhookSiteEvent)
             and event_spec_content.new_submission
         ):
-            submission = ctx.principal_view.submission_for_visitor_schema_from_orm(
-                event.submission
-            )
+            submission = ctx.principal_view.submission_schema_from_orm(event.submission)
             if submission:
                 _post_webhook(
                     webhook,

--- a/chafan_core/app/user_permission.py
+++ b/chafan_core/app/user_permission.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from chafan_core.app import crud, models
 from chafan_core.app.common import OperationType
-from chafan_core.app.model_utils import is_live_answer
+from chafan_core.app.model_utils import is_live_answer, is_live_article
 from chafan_core.utils.base import ContentVisibility, HTTPException_
 
 import logging
@@ -53,6 +53,7 @@ def user_in_site(
 def article_read_allowed(
     db: Session, article: models.Article, user_id: Optional[int]
 ) -> bool:
+    """Read gate for the full article payload (body included)."""
     if article.is_published and article.visibility == ContentVisibility.ANYONE:
         return True
     if article.author_id == user_id and user_id is not None:
@@ -60,6 +61,26 @@ def article_read_allowed(
 
     logger.info(f"User {user_id} is not allowed to read article {article.id}")
     return False
+
+
+def article_preview_read_allowed(
+    article: models.Article, user_id: Optional[int]
+) -> bool:
+    """Binary read gate for article previews: one predicate for any principal.
+
+    Authors always; otherwise the article must be live. Anonymous principals
+    additionally require ANYONE visibility. Looser than
+    :func:`article_read_allowed`, which gates the full body.
+    """
+    if article.is_deleted:
+        return False
+    if user_id is not None and user_id == article.author_id:
+        return True
+    if not is_live_article(article):
+        return False
+    if user_id is None:
+        return article.visibility == ContentVisibility.ANYONE
+    return True
 
 
 def question_read_allowed(
@@ -109,14 +130,6 @@ def can_read_answer(db: Session, *, answer: models.Answer, principal_id: int) ->
     return user_in_site(
         db, site=answer.site, user_id=principal_id, op_type=OperationType.ReadSite
     )
-
-
-def visitor_can_read_answer(*, answer: models.Answer) -> bool:
-    if not is_live_answer(answer):
-        return False
-    if answer.visibility != ContentVisibility.ANYONE:
-        return False
-    return bool(answer.site.public_readable)
 
 
 def check_user_in_site(

--- a/chafan_core/tests/app/test_user_permission.py
+++ b/chafan_core/tests/app/test_user_permission.py
@@ -1,0 +1,64 @@
+"""Unit tests for the article preview read gate.
+
+`article_preview_read_allowed` replaced the `can_read_article` /
+`visitor_can_read_article` pair in responders/article.py (D2: one predicate
+per resource, "public or authorized", no visitor twin). The two old paths
+differed only for anonymous principals reading a non-ANYONE article, so that
+branch is pinned here — the API tests all create articles with
+`visibility: "anyone"`.
+"""
+
+from types import SimpleNamespace
+
+from chafan_core.app.user_permission import article_preview_read_allowed
+from chafan_core.utils.base import ContentVisibility
+
+AUTHOR_ID = 1
+OTHER_USER_ID = 2
+
+
+def _article(
+    *,
+    is_deleted: bool = False,
+    is_published: bool = True,
+    visibility: ContentVisibility = ContentVisibility.ANYONE,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        is_deleted=is_deleted,
+        is_published=is_published,
+        visibility=visibility,
+        author_id=AUTHOR_ID,
+    )
+
+
+def test_author_may_read_own_unpublished_article():
+    assert article_preview_read_allowed(_article(is_published=False), AUTHOR_ID)
+
+
+def test_deleted_article_hidden_from_everyone_including_author():
+    article = _article(is_deleted=True)
+    assert not article_preview_read_allowed(article, AUTHOR_ID)
+    assert not article_preview_read_allowed(article, OTHER_USER_ID)
+    assert not article_preview_read_allowed(article, None)
+
+
+def test_unpublished_article_hidden_from_non_authors():
+    article = _article(is_published=False)
+    assert not article_preview_read_allowed(article, OTHER_USER_ID)
+    assert not article_preview_read_allowed(article, None)
+
+
+def test_live_article_readable_by_any_authenticated_principal():
+    """Authenticated non-authors see live articles regardless of visibility."""
+    assert article_preview_read_allowed(_article(), OTHER_USER_ID)
+    assert article_preview_read_allowed(
+        _article(visibility=ContentVisibility.REGISTERED), OTHER_USER_ID
+    )
+
+
+def test_anonymous_requires_anyone_visibility():
+    """The one branch where the old visitor twin was stricter."""
+    assert article_preview_read_allowed(_article(), None)
+    assert not article_preview_read_allowed(
+        _article(visibility=ContentVisibility.REGISTERED), None
+    )

--- a/docs/proposals/2026-07-15-target-architecture.md
+++ b/docs/proposals/2026-07-15-target-architecture.md
@@ -1,10 +1,24 @@
-# Target Architecture — Working Draft
+# Target Architecture
 
-**Status:** draft for discussion | **Date:** 2026-07-15
+**Status:** adopted; steps 0–3 landed, step 4 in progress | **Date:** 2026-07-15 | **Last reviewed:** 2026-07-24
 
 Two parts: (1) the ideal structure of chafan-core, (2) the implementation plan to get there.
 
 Relationship to `chafan_backend_improve_v2/`: this draft does not replace the v2 proposals. It gives them a structural destination. Where a step below overlaps a v2 proposal, the proposal is referenced and stays the source of truth for its own details.
+
+## Progress at a glance (2026-07-24)
+
+| Step | Status | Landed in |
+|---|---|---|
+| 0. Responder permission stubs | **done** | `18ac15d` |
+| 1. Materialize kill (per-resource) | **done** | #119, #137, #143, #144, #151 + intermediate commits |
+| 2. Dramatiq removal | **done** | `a5554a2`, `c04eda1`, #146 |
+| 3. Cache reduction / CachedLayer breakup | **done** | #124, #125, #147, #148, #149, #153 |
+| 4. Services + crud demotion | **in progress** | see the task list under step 4 |
+
+The five levels now exist as directories: `api/endpoints/` (40 files), `services/` (39 modules), `responders/` (14), `crud/` (30), and `infra/`. `cached_layer.py`, `materialize.py`, `data_broker.py`, `task.py`, `task_utils.py`, `simple_session.py`, the Dramatiq broker and its 17 actors, `ReadSessionLocal`/`use_read_replica`, and the `*ForVisitor` schema family are all deleted. The import ratchet (`scripts/static_analysis/check_layer_imports.py`) runs in CI and is green.
+
+What is *not* yet true: `CRUDBase` still exists with 27 inheritors, three endpoints still carry business logic and commit directly, and both `RequestContext` and `PrincipalView` are larger than their target shape. Details in step 4.
 
 ---
 
@@ -43,14 +57,14 @@ These were settled during the 2026-07 architecture review; they are inputs, not 
 └────────────────────────────────────────────────────────┘
 ```
 
-**The one structural rule: imports point downward only.** Level N may import N+1 and below, never sideways into another level-2 domain's internals (use its public service functions), never upward. This is the rule that dissolves today's circular-import cluster (`cached_layer ↔ materialize ↔ feed ↔ view_counters`).
+**The one structural rule: imports point downward only.** Level N may import N+1 and below, never sideways into another level-2 domain's internals (use its public service functions), never upward. This is the rule that dissolves the then-current circular-import cluster (`cached_layer ↔ materialize ↔ feed ↔ view_counters`) — since dissolved, and now enforced in CI by the step 4 ratchet.
 
 ### Level 1 — `api/endpoints/`
 
 - Parses/validates the request, resolves auth via `deps.py`, calls **one** service function, returns its schema.
 - May import: `services/`, `schemas/`, `deps`.
 - May NOT import: `crud`, `responders`, `models` internals, redis, or reach through objects (`x.materializer.y`).
-- Today all 32 endpoint files import `crud` directly and 28 reach into `cached_layer.materializer.*`. That traffic all moves behind service functions.
+- At the time of writing, all 32 endpoint files imported `crud` directly and 28 reached into `cached_layer.materializer.*`. That traffic all moves behind service functions. *(As of 2026-07-24: 2 of 40 endpoint files still import `crud`/`responders`, both on the ratchet allowlist; no endpoint reaches through objects any more.)*
 
 ### Level 2 — `services/`
 
@@ -122,17 +136,17 @@ Migration note: crud methods lose their internal `db.commit()` as they're demote
 
 ## 1.4 What ceases to exist
 
-| Today | Fate |
-|---|---|
-| `cached_layer.py` (1,019 lines) | dissolved: context → `RequestContext`, caching → `cache.py`, business logic → `services/`, rec computations → `recs/` |
-| `materialize.py` (1,148 lines) | dissolved per-resource into `responders/` + `user_permission.py`; `*ForVisitor` halves deleted outright (D2) |
-| `data_broker.py` | merged into `RequestContext`; `use_read_replica` deleted (D6) |
-| Dramatiq (broker, 17 actors' plumbing, worker screen session, nix dep) | deleted; bodies become service functions on `BackgroundTasks` |
-| `task_utils.py` | deleted (already marked for removal); services own sessions/commits explicitly |
-| `crud/base.py` `CRUDBase` | deleted; crud modules become plain functions |
-| `schemas/*ForVisitor` + their responders/cache keys | deleted (D2) |
-| `ReadSessionLocal`, `simple_session.py` | deleted (D6) |
-| `task.py` (762 lines) | split: actor bodies → `services/`; `write_view_count_to_db` → `services/viewcounts.py`; `refresh_search_index` → `services/search.py` |
+| Today | Fate | Status |
+|---|---|---|
+| `cached_layer.py` (1,019 lines) | dissolved: context → `RequestContext`, caching → `cache.py`, business logic → `services/`, rec computations → `recs/` | **done** |
+| `materialize.py` (1,148 lines) | dissolved per-resource into `responders/` + `user_permission.py`; `*ForVisitor` halves deleted outright (D2) | **done** |
+| `data_broker.py` | merged into `RequestContext`; `use_read_replica` deleted (D6) | **done** |
+| Dramatiq (broker, 17 actors' plumbing, worker screen session, nix dep) | deleted; bodies become service functions on `BackgroundTasks` | **done** |
+| `task_utils.py` | deleted (already marked for removal); services own sessions/commits explicitly | **done** |
+| `crud/base.py` `CRUDBase` | deleted; crud modules become plain functions | **not started** — 27 inheritors; mutating methods already flush-only, so it is inert but present |
+| `schemas/*ForVisitor` + their responders/cache keys | deleted (D2) | **done** — schemas in #119/#151, the surviving alias methods and dual predicate in the D2 follow-up (see below) |
+| `ReadSessionLocal`, `simple_session.py` | deleted (D6) | **done** |
+| `task.py` (762 lines) | split: actor bodies → `services/`; `write_view_count_to_db` → `services/viewcounts.py`; `refresh_search_index` → `services/search.py` | **done** (#146) |
 
 ---
 
@@ -140,7 +154,7 @@ Migration note: crud methods lose their internal `db.commit()` as they're demote
 
 Ordering principle: correctness first, then deletions that shrink the surface, then the structural moves. Every step lands independently; no big-bang. Avoid DB migrations throughout (v2 principle 7) — nothing below needs one.
 
-## Step 0 — Fix the responder permission/data stubs
+## Step 0 — Fix the responder permission/data stubs — **done** (`18ac15d`)
 
 **Urgency: this is a live issue, not tech debt** (D3: private sites exist).
 
@@ -149,7 +163,7 @@ Ordering principle: correctness first, then deletions that shrink the surface, t
 
 Small diff, no structural change, ships first.
 
-## Step 1 — Resume the materialize kill, per-resource
+## Step 1 — Resume the materialize kill, per-resource — **done**
 
 Recipe, one resource per PR (question, answer, submission, article, comment, then the small fry):
 
@@ -160,7 +174,19 @@ Recipe, one resource per PR (question, answer, submission, article, comment, the
 
 Overlaps: proposal 14's schema-collapse intent is executed here per-resource rather than as a separate pass. D2 means roughly half of materialize is deleted rather than migrated.
 
-## Step 2 — Remove Dramatiq
+**D2 completion note (2026-07-24).** Deleting the `*ForVisitor` *schemas* in #119/#151 left three kinds of residue behind, since found and removed:
+
+- Three pass-through alias methods on `PrincipalView` (`preview_of_question_for_visitor`, `preview_of_answer_for_visitor`, `submission_for_visitor_schema_from_orm`) that only forwarded to their non-visitor counterpart. Two had no callers at all.
+- `visitor_can_read_answer` in `user_permission.py` — dead once `answer_read_allowed` absorbed the anonymous case.
+- One genuinely-live dual path: `responders/article.py` branched on `if principal_id:` between local `can_read_article` and `visitor_can_read_article` predicates. Both are now `user_permission.article_preview_read_allowed`, written to the same shape as `answer_read_allowed` — one predicate, anonymous handled by a branch inside it. This also removed the last permission logic from a responder body (§1.2 forbids it there).
+
+Lesson for the remaining steps: deleting a schema twin is not the same as deleting the code path that fed it. Grep for the snake_case form (`for_visitor`) as well as the class name.
+
+Coverage gap this exposed: every article API test creates articles with `visibility: "anyone"`, so the anonymous/non-ANYONE branch — the only case where the two old predicates disagreed — had no test. Pinned by `tests/app/test_user_permission.py`.
+
+Known asymmetry left in place deliberately: `article_read_allowed` (full body) is *stricter* than `article_preview_read_allowed`, requiring ANYONE visibility even for authenticated non-authors. That is a payload distinction rather than a principal-type twin, so it is not a D2 violation, but it looks unintentional and is security-relevant. Worth a deliberate decision rather than a silent change.
+
+## Step 2 — Remove Dramatiq — **done** (`a5554a2`, `c04eda1`, #146)
 
 1. In the 8 dispatching endpoint files, replace `run_dramatiq_task(postprocess_x, id)` with `background_tasks.add_task(postprocess_x, id)`.
 2. Strip `@dramatiq.actor` decorators; drop the broker setup (`task.py:71-74`), `run_dramatiq_task` (`common.py`), `task_utils.py` (inline explicit session/commit into each function).
@@ -171,7 +197,7 @@ Caveats accepted by D4/D5: tasks die with the process (bar is already best-effor
 
 Overlaps: extends proposals 04/05 (scheduled consolidation, fake-async cleanup).
 
-## Step 3 — Cache scope reduction = CachedLayer breakup
+## Step 3 — Cache scope reduction = CachedLayer breakup — **done** (#124, #125, #147, #148, #149, #153)
 
 Proposal 13 stays the source of truth for scope and invalidation design (including its Appendix A/B design-note gate). This draft reframes its execution as the structural refactor:
 
@@ -182,28 +208,61 @@ Proposal 13 stays the source of truth for scope and invalidation design (includi
 
 Gate: proposal 13's measurement prerequisite (16-measurement-infra) applies to the *what stays cached* decision. The structural moves in (2)–(3) don't need measurement and can proceed; when in doubt whether a payload is "heavy," drop the cache — it can be re-added behind `cache.py` later with one line.
 
-## Step 4 — Services extraction + crud demotion (opportunistic, ongoing)
+**Outcome (2026-07-24).** The "when in doubt, drop the cache" escape hatch got taken almost everywhere. `infra/cache.py` is 54 lines with exactly one `get_or_set` caller (`services/invitations.py`, the daily invitation-link id). The **version-key invalidation scheme from 13C was never built, because nothing left in the codebase needs it** — the content caches are gone rather than reduced, and the remaining Redis keys are ephemeral operational state (view-bump queue, OTP). Proposal 13's measurement gate (16-measurement-infra) is therefore moot as a prerequisite: there is no "what stays cached" decision outstanding.
 
-No dedicated migration. Standing rule once steps 0–3 land:
+Consequence to accept deliberately: **every content read now hits Postgres.** That was the bet in D1 (on-prem Postgres is cheap and fast). If a payload ever measures too slow, re-add it behind `cache.py` — and *that* is the point at which 13C's version keys need building, not before.
+
+## Step 4 — Services extraction + crud demotion — **in progress**
+
+The standing rule (unchanged):
 
 - Touching an endpoint? Move its business logic into `services/<domain>.py`; the endpoint shrinks to parse → call → return.
 - Touching a crud module? Replace its `CRUDBase` inheritance with plain functions; move any commits up into the calling service. Delete `crud/base.py` when the last inheritor is gone.
 - New code follows the layer rules from day one.
 
-Optional ratchet: a small import-linter check (endpoints may not import crud/responders; responders may not import services; etc.) turns the architecture from convention into a CI guarantee. Cheap to add after step 3.
+Ratchet: built and running in CI as `scripts/static_analysis/check_layer_imports.py` (#148, hardened #149). It enforces four rules — no imports of deleted modules, responders ↛ services, crud ↛ services/responders/api, api ↛ crud/responders.
+
+### Remaining work, concretely
+
+Opportunistic drift has taken this as far as it goes; the items below need deliberate scheduling.
+
+1. **Delete `CRUDBase`.** 27 of 30 crud modules still inherit it. Mutating methods were already demoted to flush-only (#145), so this is inert and mechanical — the largest remaining diff at the lowest risk.
+
+2. **The last three fat endpoints.** `login.py` (543 lines), `me.py` (452), `people.py` (333). These hold the only remaining endpoint-level `db.commit()` calls — `login.py:84,359,378,484` and `people.py:142` — and are therefore the last violations of §1.3's single-transaction-boundary rule. They are also the only entries on the ratchet's temporary allowlist (`login.py`, `people.py` importing `crud`/`responders`). **Clearing these three clears the allowlist and closes the atomicity hole; do them first.**
+
+3. **`RequestContext` is 193 lines, not the ~50 in §1.2.** It still carries schema-shaping and query delegation inherited from `CachedLayer`: `preview_of_user`, `preview_of_answer`, `site_schema_from_orm`, `channel_schema_from_orm`, `get_user_follows`, `get_site_by_subdomain`, `get_site_info`, `update_notification`, `get_follow_follow_fanout`, `get_user_contributions`, plus a `broker` property that returns `self`. Each uses a function-local import to dodge the cycle it would otherwise recreate — a reliable smell that the method is in the wrong layer. These should become direct service/responder calls at the call sites.
+
+4. **`PrincipalView` (233 lines) is level-3 work sitting in level 5.** It is a ~30-method dispatch table from ORM object to schema, i.e. exactly what `responders/` is for, but it lives in `infra/`. Either relocate it to `responders/` or let call sites hit responders directly and delete it. Note the ratchet cannot currently catch this, because `infra/` has no outbound rule.
+
+5. **Root-level modules superseded but not removed.** `app/view_counters.py` (59 lines) and `app/search.py` (80) coexist with `services/viewcounts.py` and `services/search.py`; endpoints and responders still call the root pair. Fold each into its service.
+
+6. **Naming residue from the dissolved modules.** `materialize_event` (`responders/event.py`, `infra/principal_view.py`), `materialize_activity` (`services/feed_impl.py`), local variables named `materializer`/`mat`, and parameters still named `data_broker`/`broker` for what is now a `RequestContext`. Cosmetic, but it is the last thing making the old architecture legible in the new one.
+
+7. **Widen the ratchet** once (2) lands and the allowlist is empty: add `services ↛ api`, `responders ↛ redis`, `api ↛ models`, and an outbound rule for `infra/`. Also make allowlist entries fail once empty, so they cannot silently regrow.
+
+8. **Test the new layers.** 42 test files, almost all endpoint- or crud-level; only two reach into `services`/`responders`/`infra`/`user_permission` directly. Nothing tests the §1.3 atomicity guarantee — that a multi-write use case (answer update, which inserts an `Archive` then updates the `Answer`) rolls back cleanly on failure. That guarantee is the main correctness claim of the whole refactor and it is currently unverified.
+
+Suggested order: 2 → 1 → 3/4 → 7 → 5/6, with 8 alongside whichever domain is being touched.
 
 ## Sequencing summary
 
-| Step | Size | Risk | Depends on |
-|---|---|---|---|
-| 0. Responder permission stubs | S | Low | — |
-| 1. Materialize kill (per-resource, ~6 PRs) | M each | Medium | 0 |
-| 2. Dramatiq removal | M | Low–Medium | — (parallel to 1) |
-| 3. Cache reduction / CachedLayer breakup | L | High (proposal 13's gates apply) | mostly 1 |
-| 4. Services + crud demotion | ongoing | Low | 0–3 |
+| Step | Size | Risk | Depends on | Status |
+|---|---|---|---|---|
+| 0. Responder permission stubs | S | Low | — | done |
+| 1. Materialize kill (per-resource, ~6 PRs) | M each | Medium | 0 | done |
+| 2. Dramatiq removal | M | Low–Medium | — (parallel to 1) | done |
+| 3. Cache reduction / CachedLayer breakup | L | High (proposal 13's gates apply) | mostly 1 | done |
+| 4. Services + crud demotion | ongoing | Low | 0–3 | in progress |
 
-## Open questions
+Actual cost of steps 0–3: roughly 30 commits across PRs #119–#154, no DB migrations (v2 principle 7 held), one production behavior change caught in review (the responder permission stubs of step 0, which were a live bug rather than debt).
 
-1. `feed.py` (413 lines) mixes activity storage, feed fanout, and reading — does it become `services/feed.py` wholesale, or split (fanout is write-path, reading is query-path)? Decide when step 3 forces the import untangling.
-2. Webhook delivery (`webhook_utils.py`) does outbound HTTP from the request process post-Dramatiq. Fine at current traffic; if a slow webhook endpoint ever hurts, move delivery to the Redis-drain queue. No action now.
-3. Does `mq.py`/ws push survive the CachedLayer breakup unchanged, or fold into `services/notifications.py`? Small either way.
+## Open questions — resolved
+
+1. **`feed.py` — split, not wholesale.** Landed in #147 as `services/feed.py` (46 lines, the read entry point) over `services/feed_impl.py` (417, storage + fanout). Deliberately *not* restructured further: feed is queued for its own redesign, and this refactor should not pre-empt those decisions. Leave it alone in passing.
+2. **Webhook delivery — no action taken, as predicted.** Now `services/webhook_delivery.py`; still does outbound HTTP in the request process. Fine at current traffic. The Redis-drain queue remains the answer if a slow endpoint ever hurts.
+3. **`mq.py` survived unchanged** (28 lines) and did not fold into `services/notifications.py`. It reads as infra, so it stays infra. Its `data_broker` parameter name is part of item 6 above.
+
+## New open questions
+
+1. Should `article_read_allowed` really be stricter than `article_preview_read_allowed` (see the D2 note under step 1)? Existing prod behavior, preserved on purpose, but likely accidental.
+2. `crud/crud_user.py:try_get_visitor_user` and `recs/indexing.py:compute_interesting_*_for_visitor_user` refer to a real anonymous-user DB row used as the rec index for logged-out visitors. This is unrelated to D2's schema split and is *not* residue — but the shared vocabulary invites confusion. Worth renaming to `anonymous_user` to keep "visitor" from meaning two things.


### PR DESCRIPTION
## Why

D2 (*no visitor/user schema split*) was marked done when the `*ForVisitor` schema classes were deleted in #119 / #151. Deleting the schemas did not delete the code paths that fed them — a `grep` for the snake_case form (`for_visitor`) rather than the class name turns up the rest.

## What survived, and what happened to it

**Three pass-through aliases on `PrincipalView`** — `preview_of_question_for_visitor`, `preview_of_answer_for_visitor`, `submission_for_visitor_schema_from_orm`. Each did nothing but forward to its non-visitor counterpart. Two had zero callers; the third's single caller (`services/webhook_delivery.py`) now calls `submission_schema_from_orm` directly.

**`visitor_can_read_answer`** in `user_permission.py` — dead code, superseded by the anonymous branch inside `answer_read_allowed`.

**One genuinely-live dual path.** `responders/article.py` branched on `if principal_id:` between two local predicates:

```python
def can_read_article(*, article, principal_id): ...          # authenticated
def visitor_can_read_article(*, article): ...                # anonymous, stricter
```

Both are replaced by a single `user_permission.article_preview_read_allowed`, written to the same shape as the existing `answer_read_allowed` — one predicate, "public or authorized", with the anonymous case handled by a branch inside it:

```python
def article_preview_read_allowed(article, user_id: Optional[int]) -> bool:
    if article.is_deleted:
        return False
    if user_id is not None and user_id == article.author_id:
        return True
    if not is_live_article(article):
        return False
    if user_id is None:
        return article.visibility == ContentVisibility.ANYONE
    return True
```

Behaviour is preserved on all four branches — each was traced against the old pair before writing. This also removes the last permission logic from a responder body, which §1.2 of the target-architecture doc forbids (*"responders never do [permission]"*).

## Test coverage gap this exposed

**Every article API test creates articles with `visibility: "anyone"`** — so the anonymous / non-ANYONE case, the *only* case where the two old predicates disagreed, had no coverage at all. `tests/app/test_user_permission.py` pins all five branches and is wired into the `unit-tests` CI job.

## Left in place deliberately

`article_read_allowed` (full body) is **stricter** than `article_preview_read_allowed`: it requires ANYONE visibility even for authenticated non-authors, where the preview gate does not. That is a payload distinction, not a principal-type twin, so it is not a D2 violation. But it looks accidental and it is security-relevant, so it is recorded as an open question in the doc rather than changed silently. **Worth a reviewer's eye.**

## Doc update

`docs/proposals/2026-07-15-target-architecture.md` still read `Status: draft for discussion` with no record that steps 0–3 had shipped across ~30 commits (#119–#154). It now carries:

- a progress table mapping each step to the PRs that delivered it;
- status on every row of the *What ceases to exist* table (`CRUDBase` is the one **not started** — 27 inheritors, inert since #145 demoted it to flush-only);
- **step 4 fleshed out with the concrete remaining work**: the three fat endpoints (`login.py`, `me.py`, `people.py`) that hold the last 5 endpoint-level `db.commit()` calls and the only ratchet-allowlist entries; `RequestContext` at 193 lines vs its ~50-line target; `PrincipalView` doing level-3 shaping from inside level-5 `infra/`; superseded root modules; naming residue; ratchet widening; and the untested §1.3 atomicity guarantee;
- an honest note on step 3: **13C's version-key invalidation scheme was never built, because the content caches were dropped rather than reduced.** One `get_or_set` caller remains repo-wide. Proposal 13's measurement gate is moot as a prerequisite; every content read now hits Postgres, which was the D1 bet;
- the three original open questions resolved, and two new ones recorded.

## Verification

- **406 passed, 9 skipped** — full suite against real Postgres 14 + Redis
- Import ratchet: **0 errors** (3 pre-existing allowlisted warnings)
- flake8 clean; mypy **net-zero change** (17 errors on touched files before and after — the same set; the one `ColumnElement[bool]` warning simply followed the moved expression)
- `grep` for `for_visitor` / `ForVisitor` / `visitor_can_read` across `app/`: **no hits**

The remaining `_for_visitor_user` names in `recs/` and `crud_user.py` refer to a real anonymous-user DB row used as the logged-out rec index. That is unrelated to D2's schema split and is left alone — though the doc now suggests renaming it to `anonymous_user`, since "visitor" currently means two different things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)