### PR TITLE
Single transaction boundary for services/; gate question archives

### DIFF
--- a/chafan_core/app/services/answer_suggest_edits.py
+++ b/chafan_core/app/services/answer_suggest_edits.py
@@ -139,7 +139,6 @@ def update_suggest_edit(
                 answer_suggest_edit.answer.contributors.append(
                     answer_suggest_edit.author
                 )
-            db.commit()
             body_rich_text = None
             if answer_suggest_edit.body:
                 assert answer_suggest_edit.body_editor

--- a/chafan_core/app/services/answers.py
+++ b/chafan_core/app/services/answers.py
@@ -141,7 +141,6 @@ def delete_draft(
     answer.body_draft = None
     answer.draft_saved_at = None
     db.add(answer)
-    db.commit()
     return data
 
 
@@ -306,7 +305,6 @@ def apply_answer_update(
             )
             db.add(archive)
             answer.archives.append(archive)
-            db.commit()
         answer_in_dict["is_published"] = True
         answer_in_dict["updated_at"] = get_utc_now()
 
@@ -435,7 +433,6 @@ def upvote_answer(ctx, *, uuid: str) -> schemas.AnswerUpvotes:
                     ),
                 ),
             )
-        db.commit()
         db.refresh(answer)
     valid_upvotes = (
         db.query(models.Answer_Upvotes)
@@ -476,7 +473,6 @@ def cancel_upvote_answer(ctx, *, uuid: str) -> schemas.AnswerUpvotes:
             op_type=OperationType.ReadSite,
         )
         answer = crud.answer.cancel_upvote(db, db_obj=answer, voter=current_user)
-        db.commit()
         db.refresh(answer)
     valid_upvotes = (
         db.query(models.Answer_Upvotes)

--- a/chafan_core/app/services/applications.py
+++ b/chafan_core/app/services/applications.py
@@ -63,6 +63,5 @@ def approve_application(ctx, *, application_id: int) -> schemas.Application:
         )
     application.pending = False
     db.add(application)
-    db.commit()
     db.refresh(application)
     return application_schema(ctx, application)

--- a/chafan_core/app/services/articles.py
+++ b/chafan_core/app/services/articles.py
@@ -164,7 +164,6 @@ def delete_draft(
     article.body_draft = None
     article.draft_saved_at = None
     db.add(article)
-    db.commit()
     return data
 
 
@@ -263,7 +262,6 @@ def update_article(
             )
             ctx.get_db().add(archive)
             article.archives.append(archive)
-            ctx.get_db().commit()
         if not article.is_published:
             article_in_dict["initial_published_at"] = utc_now
         article_in_dict["is_published"] = True
@@ -391,7 +389,6 @@ def upvote_article(ctx, *, uuid: str) -> schemas.ArticleUpvotes:
             payer=current_user,
             payee=article.author,
         )
-    db.commit()
     db.refresh(article)
     valid_upvotes = (
         db.query(models.ArticleUpvotes)
@@ -424,7 +421,6 @@ def cancel_upvote_article(ctx, *, uuid: str) -> schemas.ArticleUpvotes:
             detail="You haven't voted yet.",
         )
     article = crud.article.cancel_upvote(db, db_obj=article, voter=current_user)
-    db.commit()
     db.refresh(article)
     valid_upvotes = (
         db.query(models.ArticleUpvotes)

--- a/chafan_core/app/services/comments.py
+++ b/chafan_core/app/services/comments.py
@@ -165,7 +165,6 @@ def upvote_comment(ctx, *, uuid: str) -> schemas.CommentUpvotes:
                 detail="Author can't upvote authored comment.",
             )
         comment = crud.comment.upvote(db, db_obj=comment, voter=current_user)
-        db.commit()
         db.refresh(comment)
     valid_upvotes = (
         db.query(models.CommentUpvotes)
@@ -201,7 +200,6 @@ def cancel_upvote_comment(ctx, *, uuid: str) -> schemas.CommentUpvotes:
     )
     if upvoted:
         comment = crud.comment.cancel_upvote(db, db_obj=comment, voter=current_user)
-        db.commit()
         db.refresh(comment)
     valid_upvotes = (
         db.query(models.CommentUpvotes)

--- a/chafan_core/app/services/feed_impl.py
+++ b/chafan_core/app/services/feed_impl.py
@@ -80,7 +80,6 @@ def new_activity_into_feed(broker: RequestContext, activity:models.Activity) -> 
                     subject_user_uuid=receivers.subject_user_uuid,
                 )
             )
-            write_db.commit()
 
 
 

--- a/chafan_core/app/services/feedbacks.py
+++ b/chafan_core/app/services/feedbacks.py
@@ -65,5 +65,4 @@ def create_feedback(
         location_url=location_url,
     )
     db.add(feedback)
-    db.commit()
     return feedback

--- a/chafan_core/app/services/invitations.py
+++ b/chafan_core/app/services/invitations.py
@@ -30,7 +30,6 @@ def try_consume_invitation_link_by_uuid(db: Session, invitation_uuid: str) -> bo
         return False
     invitation_link.remaining_quota -= 1
     db.add(invitation_link)
-    db.commit()
     return True
 
 
@@ -122,4 +121,3 @@ def join_site_with_invitation_link(ctx, *, uuid: str) -> None:
         )
         invitation_link.remaining_quota -= 1
         db.add(invitation_link)
-        db.commit()

--- a/chafan_core/app/services/postprocess.py
+++ b/chafan_core/app/services/postprocess.py
@@ -200,7 +200,6 @@ def postprocess_new_comment(
                     event_json=event.json(),
                 )
             )
-            broker.get_db().commit()
 
     execute_with_broker(runnable)
 
@@ -225,7 +224,6 @@ def postprocess_comment_update(
                     event_json=event.json(),
                 )
             )
-            broker.get_db().commit()
         if mentioned:
             notify_mentioned_users(
                 broker,
@@ -265,7 +263,6 @@ def postprocess_new_question(question_id: int) -> None:
         db = broker.get_db()
         db.add(question_ac)
         db.flush()
-        db.commit()
         new_activity_into_feed(broker, question_ac)
         postprocess_question_common(question)
         for webhook in question.site.webhooks:
@@ -463,7 +460,6 @@ def postprocess_new_answer(answer_id: int, was_published: bool) -> None:
             db = broker.get_db()
             db.add(answer_ac)
             db.flush()
-            db.commit()
             new_activity_into_feed(broker, answer_ac)
         for user in answer.bookmarkers:
             crud.notification.create_with_content(
@@ -512,7 +508,6 @@ def postprocess_new_article(article_id: int) -> None:
         db = broker.get_db()
         db.add(article_ac)
         db.flush()
-        db.commit()
         new_activity_into_feed(broker, article_ac)
         # TODO FIXME TABLE activitity 里同一篇文章有两条记录。看起来无害就先不管了 2025-aug-04
 

--- a/chafan_core/app/services/questions.py
+++ b/chafan_core/app/services/questions.py
@@ -72,7 +72,19 @@ def require_question_schema(ctx, question: models.Question) -> schemas.Question:
     return question_data
 
 
-def get_question(ctx, *, uuid: str) -> schemas.Question:
+def get_readable_question_http(ctx, uuid: str) -> models.Question:
+    """Fetch question if the principal may read it, else raise 404/403/400.
+
+    The read gate for every question-scoped endpoint. Anything derived from a
+    question (archives, ...) must go through here so it can never end up more
+    permissive than the question itself.
+
+    Two gates, deliberately separate: `get_readable_question` covers hidden
+    questions, and the site-membership check mirrors the one inside
+    `responders.question.question_schema_from_orm`, which returns None for a
+    non-member and which `require_question_schema` reports as 400. Callers that
+    do not build the full schema would otherwise miss it entirely.
+    """
     question = get_readable_question(
         ctx.get_db(),
         uuid=uuid,
@@ -89,7 +101,23 @@ def get_question(ctx, *, uuid: str) -> schemas.Question:
             status_code=403,
             detail="Not allowed to access this quesion",
         )
-    return require_question_schema(ctx, question)
+    if not user_in_site(
+        ctx.get_db(),
+        site=question.site,
+        user_id=ctx.principal_id,
+        op_type=OperationType.ReadSite,
+    ):
+        # Same status and detail require_question_schema produces, so the
+        # observable behaviour of get_question is unchanged.
+        raise HTTPException_(
+            status_code=400,
+            detail="The question doesn't exist in the system.",
+        )
+    return question
+
+
+def get_question(ctx, *, uuid: str) -> schemas.Question:
+    return require_question_schema(ctx, get_readable_question_http(ctx, uuid))
 
 
 def bump_views(ctx, *, uuid: str) -> None:
@@ -214,6 +242,20 @@ def update_question(
     editor_id = question.editor_id
     if editor_id is None:
         editor_id = question.author_id
+    # Resolve topics before snapshotting: a bad uuid must reject the edit
+    # without having built an archive of a revision that never happened.
+    new_topics = None
+    if question_in.topic_uuids is not None:
+        new_topics = []
+        for topic_uuid in question_in.topic_uuids:
+            topic = crud.topic.get_by_uuid(db, uuid=topic_uuid)
+            if topic is None:
+                raise HTTPException_(
+                    status_code=400,
+                    detail="The topic doesn't exist.",
+                )
+            new_topics.append(topic)
+        question_in.topic_uuids = None
     archive = models.QuestionArchive(
         question_id=question.id,
         title=question.title,
@@ -226,18 +268,7 @@ def update_question(
     archive.topics = question.topics
     db.add(archive)
     question.archives.append(archive)
-    db.commit()
-    if question_in.topic_uuids is not None:
-        new_topics = []
-        for topic_uuid in question_in.topic_uuids:
-            topic = crud.topic.get_by_uuid(db, uuid=topic_uuid)
-            if topic is None:
-                raise HTTPException_(
-                    status_code=400,
-                    detail="The topic doesn't exist.",
-                )
-            new_topics.append(topic)
-        question_in.topic_uuids = None
+    if new_topics is not None:
         question = crud.question.update_topics(
             db, db_obj=question, new_topics=new_topics
         )
@@ -258,7 +289,7 @@ def update_question(
 def list_archives(ctx, *, uuid: str) -> list[schemas.QuestionArchive]:
     from chafan_core.app.responders import archives as archives_responder
 
-    question = get_question_model_http(ctx.get_db(), uuid)
+    question = get_readable_question_http(ctx, uuid)
     mat = ctx.principal_view
     return [
         archives_responder.question_archive_schema_from_orm(mat, a)
@@ -380,7 +411,6 @@ def upvote_question(ctx, *, uuid: str) -> schemas.QuestionUpvotes:
                 payer=current_user,
                 payee=question.author,
             )
-        db.commit()
         db.refresh(question)
     valid_upvotes = (
         db.query(models.QuestionUpvotes)
@@ -415,7 +445,6 @@ def cancel_upvote_question(ctx, *, uuid: str) -> schemas.QuestionUpvotes:
     )
     if upvoted:
         question = crud.question.cancel_upvote(db, db_obj=question, voter=current_user)
-        db.commit()
         db.refresh(question)
     valid_upvotes = (
         db.query(models.QuestionUpvotes)

--- a/chafan_core/app/services/rewards.py
+++ b/chafan_core/app/services/rewards.py
@@ -135,7 +135,6 @@ def claim_reward(ctx, *, reward_id: int) -> schemas.Reward:
     reward.claimed_at = utc_now
     coins.award_coins(db, current_user, reward.coin_amount, "reward_claim")
     db.add(reward)
-    db.commit()
     db.refresh(reward)
     reward_data = misc_responder.reward_schema_from_orm(ctx.principal_view, reward)
     reward_event = None
@@ -185,6 +184,5 @@ def refund_reward(ctx, *, reward_id: int) -> schemas.Reward:
     reward.refunded_at = utc_now
     coins.award_coins(db, current_user, reward.coin_amount, "reward_refund")
     db.add(reward)
-    db.commit()
     db.refresh(reward)
     return misc_responder.reward_schema_from_orm(ctx.principal_view, reward)

--- a/chafan_core/app/services/sites.py
+++ b/chafan_core/app/services/sites.py
@@ -300,7 +300,6 @@ def config_site(
             new_topics.append(topic)
         new_site.topics = new_topics
         db.add(new_site)
-        db.commit()
     return site_schema(ctx, new_site)
 
 
@@ -453,7 +452,6 @@ def remove_my_site_membership(ctx, *, uuid: str) -> None:
         owner_id=ctx.unwrapped_principal_id(),
         site_id=site.id,
     )
-    db.commit()
 
 
 def get_webhooks(ctx, *, uuid: str) -> List[schemas.Webhook]:

--- a/chafan_core/app/services/submission_suggestions.py
+++ b/chafan_core/app/services/submission_suggestions.py
@@ -137,7 +137,6 @@ def update_suggestion(
                 submission_suggestion.submission.contributors.append(
                     submission_suggestion.author
                 )
-            db.commit()
             desc = None
             if submission_suggestion.description:
                 desc = RichText(

--- a/chafan_core/app/services/submissions.py
+++ b/chafan_core/app/services/submissions.py
@@ -203,18 +203,9 @@ def apply_submission_update(
 ) -> Tuple[models.Submission, Optional[schemas.Submission]]:
     """Apply an update to an existing submission model (used by suggestions accept)."""
     db = ctx.get_db()
-    archive = models.SubmissionArchive(
-        submission_id=submission.id,
-        title=submission.title,
-        description=submission.description,
-        description_editor=submission.description_editor,
-        description_text=submission.description_text,
-        topic_uuids=[t.uuid for t in submission.topics],
-        created_at=submission.updated_at,
-    )
-    db.add(archive)
-    submission.archives.append(archive)
-    db.commit()
+    # Resolve topics before snapshotting: a bad uuid must reject the edit
+    # without having built an archive of a revision that never happened.
+    new_topics = None
     if submission_in.topic_uuids is not None:
         new_topics = []
         for topic_uuid in submission_in.topic_uuids:
@@ -226,6 +217,18 @@ def apply_submission_update(
                 )
             new_topics.append(topic)
         submission_in.topic_uuids = None
+    archive = models.SubmissionArchive(
+        submission_id=submission.id,
+        title=submission.title,
+        description=submission.description,
+        description_editor=submission.description_editor,
+        description_text=submission.description_text,
+        topic_uuids=[t.uuid for t in submission.topics],
+        created_at=submission.updated_at,
+    )
+    db.add(archive)
+    submission.archives.append(archive)
+    if new_topics is not None:
         submission = crud.submission.update_topics(
             db, db_obj=submission, new_topics=new_topics
         )
@@ -380,7 +383,6 @@ def upvote_submission(ctx, *, uuid: str) -> schemas.SubmissionUpvotes:
                 payer=current_user,
                 payee=submission.author,
             )
-        db.commit()
         db.refresh(submission)
     valid_upvotes = (
         db.query(models.SubmissionUpvotes)
@@ -419,7 +421,6 @@ def cancel_upvote_submission(ctx, *, uuid: str) -> schemas.SubmissionUpvotes:
         submission = crud.submission.cancel_upvote(
             db, db_obj=submission, voter=current_user
         )
-        db.commit()
         db.refresh(submission)
     valid_upvotes = (
         db.query(models.SubmissionUpvotes)

--- a/chafan_core/tests/app/api/api_v1/test_questions.py
+++ b/chafan_core/tests/app/api/api_v1/test_questions.py
@@ -2,9 +2,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from chafan_core.app import crud
+from chafan_core.app import crud, models
 from chafan_core.app.config import settings
-from chafan_core.tests.conftest import ensure_user_in_site
+from chafan_core.tests.conftest import ensure_user_has_coins, ensure_user_in_site
 from chafan_core.tests.utils.utils import random_lower_string
 
 
@@ -437,3 +437,279 @@ def test_get_question_upvotes(
     db_question = crud.question.get_by_uuid(db, uuid=question_uuid)
     assert db_question is not None
     assert db_question.upvotes_count == data["count"]
+
+
+# =============================================================================
+# Archive Atomicity Tests
+# =============================================================================
+
+
+def _create_question(
+    client: TestClient,
+    normal_user_token_headers: dict,
+    example_site_uuid: str,
+) -> str:
+    r = client.post(
+        f"{settings.API_V1_STR}/questions/",
+        headers=normal_user_token_headers,
+        json={
+            "site_uuid": example_site_uuid,
+            "title": f"Question for archives {random_lower_string()}",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    return r.json()["uuid"]
+
+
+def test_rejected_question_update_writes_no_archive(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+) -> None:
+    """A rejected edit must leave no trace.
+
+    update_question used to commit the QuestionArchive before validating
+    topic_uuids, so a 400 rolled back the update but kept an archive row
+    describing a revision that never happened.
+    """
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    original_title = question.title
+    archives_before = len(question.archives)
+
+    r = client.put(
+        f"{settings.API_V1_STR}/questions/{question_uuid}",
+        headers=normal_user_token_headers,
+        json={
+            "title": f"Rejected update {random_lower_string()}",
+            "topic_uuids": ["nonexistent-topic-uuid"],
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "The topic doesn't exist."
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    assert len(question.archives) == archives_before, (
+        "rejected update left an orphan archive row"
+    )
+    assert question.title == original_title
+
+
+def test_repeated_rejected_updates_write_no_archives(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+) -> None:
+    """Retrying a rejected edit must not accumulate archive rows."""
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    archives_before = len(question.archives)
+
+    for _ in range(3):
+        r = client.put(
+            f"{settings.API_V1_STR}/questions/{question_uuid}",
+            headers=normal_user_token_headers,
+            json={
+                "title": f"Rejected {random_lower_string()}",
+                "topic_uuids": ["nonexistent-topic-uuid"],
+            },
+        )
+        assert r.status_code == 400
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    assert len(question.archives) == archives_before
+
+
+def test_accepted_question_update_writes_one_archive(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+) -> None:
+    """Happy path still archives: removing the mid-function commit must not
+    stop a successful edit from recording its prior revision."""
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    original_title = question.title
+    archives_before = len(question.archives)
+
+    new_title = f"Accepted update {random_lower_string()}"
+    r = client.put(
+        f"{settings.API_V1_STR}/questions/{question_uuid}",
+        headers=normal_user_token_headers,
+        json={"title": new_title},
+    )
+    assert r.status_code == 200, r.json()
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+    assert question.title == new_title
+    assert len(question.archives) == archives_before + 1
+    assert original_title in [a.title for a in question.archives]
+
+
+# =============================================================================
+# Archive Authorization Tests
+# =============================================================================
+
+
+def test_get_question_archives_as_author(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+) -> None:
+    """The author (a site member) can read revision history."""
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    r = client.get(
+        f"{settings.API_V1_STR}/questions/{question_uuid}/archives/",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_get_question_archives_unauthenticated(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+) -> None:
+    """Anonymous callers must not read revision history of a private site.
+
+    list_archives previously performed no permission check at all, so question
+    revision history was world-readable regardless of site visibility.
+    """
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    r = client.get(f"{settings.API_V1_STR}/questions/{question_uuid}/archives/")
+    assert r.status_code != 200, "anonymous read of private-site archives"
+    assert r.status_code in (400, 401, 403, 404)
+
+
+# =============================================================================
+# Background Postprocess Tests
+# =============================================================================
+
+
+def test_new_question_writes_activity_and_feed(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    moderator_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    moderator_user_id: int,
+    example_site_uuid: str,
+) -> None:
+    """postprocess_new_question must persist both the Activity and its feed fanout.
+
+    These run under execute_with_broker, which has no request boundary; the
+    Activity used to be committed mid-function before new_activity_into_feed
+    ran. Removing that commit means the flush alone has to assign activity.id,
+    and the single boundary at the end has to cover both writes.
+    """
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+
+    # Feed rows fan out to the subject's followers, so give the author one.
+    r = client.post(
+        f"{settings.API_V1_STR}/me/follows/{normal_user_uuid}",
+        headers=moderator_user_token_headers,
+    )
+    assert r.status_code == 200, r.json()
+
+    question_uuid = _create_question(
+        client, normal_user_token_headers, example_site_uuid
+    )
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=question_uuid)
+    assert question is not None
+
+    activities = (
+        db.query(models.Activity).filter_by(site_id=question.site_id).all()
+    )
+    assert activities, "postprocess_new_question persisted no Activity"
+    activity_ids = [a.id for a in activities]
+
+    feeds = (
+        db.query(models.Feed)
+        .filter(
+            models.Feed.receiver_id == moderator_user_id,
+            models.Feed.activity_id.in_(activity_ids),
+        )
+        .all()
+    )
+    assert feeds, "Activity landed but its feed fanout did not"

--- a/chafan_core/tests/app/api/api_v1/test_submissions.py
+++ b/chafan_core/tests/app/api/api_v1/test_submissions.py
@@ -710,3 +710,131 @@ def test_get_submission_suggestions_nonexistent(
     # Verify it doesn't exist in database
     db_submission = crud.submission.get_by_uuid(db, uuid="invalid-uuid")
     assert db_submission is None
+
+
+# =============================================================================
+# Archive Atomicity Tests
+# =============================================================================
+
+
+def test_rejected_submission_update_writes_no_archive(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+    example_submission_uuid: str,
+) -> None:
+    """A rejected submission edit must leave no archive row behind.
+
+    apply_submission_update used to commit the SubmissionArchive before
+    validating topic_uuids.
+    """
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+
+    db.expire_all()
+    submission = crud.submission.get_by_uuid(db, uuid=example_submission_uuid)
+    assert submission is not None
+    original_title = submission.title
+    archives_before = len(submission.archives)
+
+    r = client.put(
+        f"{settings.API_V1_STR}/submissions/{example_submission_uuid}",
+        headers=normal_user_token_headers,
+        json={
+            "title": f"Rejected update {random_lower_string()}",
+            "topic_uuids": ["nonexistent-topic-uuid"],
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "The topic doesn't exist."
+
+    db.expire_all()
+    submission = crud.submission.get_by_uuid(db, uuid=example_submission_uuid)
+    assert submission is not None
+    assert len(submission.archives) == archives_before, (
+        "rejected update left an orphan archive row"
+    )
+    assert submission.title == original_title
+
+
+def test_failed_suggestion_accept_leaves_all_tables_consistent(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+    example_submission_uuid: str,
+) -> None:
+    """Accepting a suggestion is one unit of work across four tables.
+
+    update_suggestion used to commit accepted_diff_base and the contributors
+    append, then call apply_submission_update which committed the archive and
+    only afterwards validated the stored topic_uuids. A failure there credited
+    a contributor and stored an accept-time snapshot on a suggestion whose edit
+    never landed.
+
+    The stored topic_uuids are poked directly because the API cannot currently
+    produce an unresolvable one -- topics are never deleted, and the create
+    path rejects a bad uuid while shaping its response. The accept path must be
+    atomic regardless.
+    """
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+
+    r = client.post(
+        f"{settings.API_V1_STR}/submission-suggestions/",
+        headers=normal_user_token_headers,
+        json={
+            "submission_uuid": example_submission_uuid,
+            "title": f"Suggested title {random_lower_string()}",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    suggestion_uuid = r.json()["uuid"]
+
+    db.expire_all()
+    suggestion = crud.submission_suggestion.get_by_uuid(db, uuid=suggestion_uuid)
+    assert suggestion is not None
+    suggestion.topic_uuids = ["nonexistent-topic-uuid"]
+    db.add(suggestion)
+    db.commit()
+
+    db.expire_all()
+    suggestion = crud.submission_suggestion.get_by_uuid(db, uuid=suggestion_uuid)
+    assert suggestion is not None
+    submission_title_before = suggestion.submission.title
+    archives_before = len(suggestion.submission.archives)
+    contributors_before = len(suggestion.submission.contributors)
+
+    r = client.put(
+        f"{settings.API_V1_STR}/submission-suggestions/{suggestion_uuid}",
+        headers=normal_user_token_headers,
+        json={"status": "accepted"},
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "The topic doesn't exist."
+
+    db.expire_all()
+    suggestion = crud.submission_suggestion.get_by_uuid(db, uuid=suggestion_uuid)
+    assert suggestion is not None
+    assert suggestion.status == "pending", "suggestion state advanced on a failed accept"
+    assert suggestion.accepted_at is None
+    assert suggestion.accepted_diff_base is None, (
+        "accept-time snapshot survived a failed accept"
+    )
+    assert len(suggestion.submission.contributors) == contributors_before, (
+        "contributor credited for an edit that never landed"
+    )
+    assert len(suggestion.submission.archives) == archives_before
+    assert suggestion.submission.title == submission_title_before

--- a/scripts/static_analysis/check_service_commits.py
+++ b/scripts/static_analysis/check_service_commits.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Ratchet: one transaction boundary per use case.
+
+Run: python scripts/static_analysis/check_service_commits.py
+
+`services/` and `crud/` must never call `.commit()`. They do `db.add()`/
+`db.flush()` and let the caller's boundary commit once:
+
+  - HTTP requests      api/deps.py get_request_context{,_logged_in} / get_db
+  - background/cron    infra/runtime.py execute_with_context / execute_with_db
+
+A commit in the middle of a service function splits the use case into two
+transactions, and neither boundary can roll back past the first one. That is
+how rejected question and submission edits came to leave orphan archive rows:
+validation raised *after* the archive had already been made durable.
+
+ALLOWLIST is empty and entries may only be removed, never added.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "chafan_core"
+
+# Directories that must not commit, relative to chafan_core/.
+GUARDED_DIRS = ("app/services", "app/crud")
+
+# Files permitted to keep a commit, keyed by path rather than path:line so a
+# moved line cannot silently re-arm the exemption. Must only ever shrink.
+ALLOWLIST: set[str] = set()
+
+
+def iter_py_files(base: Path):
+    for path in base.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def is_guarded(path: Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    return any(rel.startswith(d + "/") for d in GUARDED_DIRS)
+
+
+def receiver_name(node: ast.expr) -> str:
+    """Best-effort name of whatever `.commit()` was called on."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return receiver_name(node.func) + "()"
+    return "<expr>"
+
+
+def is_db_receiver(name: str) -> bool:
+    """True for session-like receivers: db, write_db, get_db(), session, ...
+
+    Deliberately excludes non-SQLAlchemy commits that share the method name --
+    `writer.commit()` on a Whoosh IndexWriter in services/search.py is not a
+    transaction boundary.
+    """
+    lowered = name.lower()
+    return "db" in lowered or "session" in lowered
+
+
+def commit_calls(path: Path) -> list[tuple[int, str]]:
+    """(line, receiver) for every `<x>.commit()` call in the file."""
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError as e:
+        print(f"SYNTAX {path}: {e}", file=sys.stderr)
+        return []
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "commit"
+        ):
+            out.append((node.lineno, receiver_name(node.func.value)))
+    return out
+
+
+def main() -> int:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for path in sorted(iter_py_files(ROOT)):
+        if not is_guarded(path):
+            continue
+        rel = path.relative_to(ROOT.parent)
+        for lineno, receiver in commit_calls(path):
+            if not is_db_receiver(receiver):
+                warnings.append(
+                    f"{rel}:{lineno}: {receiver}.commit() ignored (not a db session)"
+                )
+                continue
+            msg = (
+                f"{rel}:{lineno}: services/crud must not commit; "
+                f"let the request or background boundary commit once"
+            )
+            if str(rel) in ALLOWLIST:
+                warnings.append(msg + " (allowlisted)")
+            else:
+                errors.append(msg)
+
+    stale = sorted(
+        entry
+        for entry in ALLOWLIST
+        if not any(
+            str(p.relative_to(ROOT.parent)) == entry for p in iter_py_files(ROOT)
+        )
+    )
+    for entry in stale:
+        warnings.append(f"{entry}: allowlist entry no longer exists; remove it")
+
+    for w in warnings:
+        print(f"WARN  {w}")
+    for e in errors:
+        print(f"ERROR {e}", file=sys.stderr)
+
+    print(f"service-commit check: {len(errors)} error(s), {len(warnings)} warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/static_analysis/lint.sh
+++ b/scripts/static_analysis/lint.sh
@@ -2,8 +2,9 @@
 
 set -xe
 
-# Architecture ratchet (must pass).
+# Architecture ratchets (must pass).
 python scripts/static_analysis/check_layer_imports.py
+python scripts/static_analysis/check_service_commits.py
 
 mypy chafan_core || true
 black chafan_core --check || true


### PR DESCRIPTION
## What

Three related changes, all rooted in `services/` functions committing mid-use-case.

**1. One transaction per use case.** A mid-function `db.commit()` splits a use case into two transactions, and neither the HTTP nor the background boundary can roll back past the first. Where a validation happened to sit after such a commit, a rejected edit left a durable `Archive` row describing a revision that never happened — reachable today from `PUT /questions/{uuid}` and `PUT /submissions/{uuid}` with an unknown `topic_uuid`.

Removed all 30 `commit()` calls from `services/`. The audit this needed turned out to be already satisfied:

- Every caller path ends in a commit — `deps.get_request_context{,_logged_in}` / `get_db` for HTTP, `infra/runtime.py` `execute_with_context` / `execute_with_db` for background and scheduled work. Nothing overrides their `auto_commit=True`, and all direct `SessionLocal()` uses go through `execute_with_db`.
- `crud` is already flush-only (`CRUDBase.update` is `add`/`flush`/`refresh`).
- `RequestContext.close()` already rolls back when uncommitted.

`db.flush()` calls are preserved — those assign the `activity.id` that `new_activity_into_feed` asserts on.

**2. Validate before snapshotting.** `update_question` and `apply_submission_update` now resolve `topic_uuids` before building the `Archive`, matching `sites.config_site`, which already did it this way.

**3. Question archives had no authorization at all.** `questions.list_archives` performed no permission check, and its endpoint accepts anonymous callers — so question revision history was world-readable regardless of site visibility. Answers and articles gate on the author; submissions gates on site membership; questions gated on nothing.

New `get_readable_question_http` is used by both `get_question` and `list_archives`. It covers the hidden-question gate **and** the site-membership check that otherwise only lives inside `responders.question.question_schema_from_orm` — a caller that doesn't build the full schema would miss it entirely. It raises the same status and detail `require_question_schema` produced, so `get_question` is observably unchanged.

**4. Ratchet.** `scripts/static_analysis/check_service_commits.py`, wired into `lint.sh` next to the existing layer-import check. Empty allowlist. It's receiver-aware — `writer.commit()` on the Whoosh `IndexWriter` in `services/search.py` is reported as a warning, not an error.

## Behaviour change to review

`new_activity_into_feed` committed **per receiver**, so a mid-fanout failure kept the earlier `Feed` rows. Fanout is now all-or-nothing — but the parent `Activity` rolls back with it, so the outcome is consistent rather than half-written. This is the one deliberate semantic change in the diff.

## Testing

Six new tests. The five regression tests **fail on `f3f2547` and pass here** (verified by stashing the service changes and re-running):

- rejected question edit leaves no archive; retries don't accumulate
- rejected submission edit leaves no archive
- a failed suggestion accept leaves `status`, `accepted_diff_base`, `contributors` and `archives` all consistent
- question archives reject anonymous access
- happy-path archives are still written

Plus `test_new_question_writes_activity_and_feed`, covering the background path — previously uncovered, since `test_feed.py` is a stub. This is what guards the `flush`-without-`commit` change in `postprocess.py`.

Full suite against Postgres 14: **412 passed, 2 failed, 9 skipped**. The two failures (`test_users.py::test_create_user_new_email`, `::test_create_user_existing_username`) are pre-existing — they fail identically on unmodified `main` with a fresh database, and only pass on a database carrying state from earlier runs.

## Note

`docs/bugs/2026-07-24-orphan-archive-partial-writes.md` is intentionally **not** in this PR. It's directionally right but wrong in specifics — its stated trigger for the answers case can't fire (`apply_answer_update` sets `is_published = True` on the same branch that writes the archive, so the `assert` in `crud_answer.update_checked` is dead there), and its "worst case" section is wrong in both trigger and damage: topics can't be deleted, and the suggestion is not left "permanently accepted" — the `status` write rolls back, which the new test confirms. Worth replacing with a link to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)