### PR TITLE
Gate /me subscription and bookmark routes on read permission

### DIFF
--- a/chafan_core/app/services/answers.py
+++ b/chafan_core/app/services/answers.py
@@ -14,12 +14,36 @@ from chafan_core.app.endpoint_utils import check_writing_session
 from chafan_core.app.schemas.answer import AnswerModUpdate
 from chafan_core.app.schemas.event import EventInternal, UpvoteAnswerInternal
 from chafan_core.app.schemas.richtext import RichText
-from chafan_core.app.user_permission import check_user_in_site
+from chafan_core.app.user_permission import answer_read_allowed, check_user_in_site
 from chafan_core.utils.base import HTTPException_, get_utc_now, unwrap
 from chafan_core.utils.constants import MAX_ARCHIVE_PAGINATION_LIMIT
 import chafan_core.app.responders as responders
 
 logger = logging.getLogger(__name__)
+
+
+def get_readable_answer_http(ctx, uuid: str) -> models.Answer:
+    """Fetch answer if the principal may read it, else raise 400.
+
+    The read gate for every answer-scoped endpoint. Anything derived from an
+    answer (bookmarks, ...) must go through here so it can never end up more
+    permissive than the answer itself.
+
+    A denied read is reported as "doesn't exist" rather than 403 on purpose:
+    `answer_read_allowed` folds site membership in, so a distinguishable
+    status would tell a non-member of a private site that the answer exists.
+    Same reasoning as the site-membership branch of
+    `services.questions.get_readable_question_http`.
+    """
+    answer = crud.answer.get_by_uuid(ctx.get_db(), uuid=uuid)
+    if answer is None or not answer_read_allowed(
+        ctx.get_db(), answer, ctx.principal_id
+    ):
+        raise HTTPException_(
+            status_code=400,
+            detail="The answer doesn't exist in the system.",
+        )
+    return answer
 
 
 def delete_answer(

--- a/chafan_core/app/services/articles.py
+++ b/chafan_core/app/services/articles.py
@@ -16,12 +16,38 @@ from chafan_core.app.endpoint_utils import check_writing_session
 from chafan_core.app.responders.archives import article_archive_schema_from_orm
 from chafan_core.app.schemas.event import EventInternal, UpvoteArticleInternal
 from chafan_core.app.schemas.richtext import RichText
-from chafan_core.app.user_permission import article_read_allowed
+from chafan_core.app.user_permission import (
+    article_preview_read_allowed,
+    article_read_allowed,
+)
 from chafan_core.utils.base import ContentVisibility, HTTPException_
 from chafan_core.utils.constants import MAX_ARCHIVE_PAGINATION_LIMIT
 import chafan_core.app.responders as responders
 
 logger = logging.getLogger(__name__)
+
+
+def get_readable_article_preview_http(ctx, uuid: str) -> models.Article:
+    """Fetch article if the principal may see its preview, else raise 400/403.
+
+    The read gate for article-scoped endpoints that do not serve the body.
+    Gates on :func:`article_preview_read_allowed` rather than
+    :func:`article_read_allowed` because the caller is not handing back the
+    article body -- see the article asymmetry noted in the target-architecture
+    doc.
+
+    A denied read is reported as "doesn't exist" rather than 403 on purpose,
+    so the status cannot tell a stranger that an unpublished article exists.
+    """
+    article = crud.article.get_by_uuid(ctx.get_db(), uuid=uuid)
+    if article is None or not article_preview_read_allowed(
+        article, ctx.principal_id
+    ):
+        raise HTTPException_(
+            status_code=400,
+            detail="The article doesn't exist in the system.",
+        )
+    return article
 
 
 def get_article_by_uuid(

--- a/chafan_core/app/services/me.py
+++ b/chafan_core/app/services/me.py
@@ -19,7 +19,10 @@ from chafan_core.app.schemas.user import (
     UserUpdatePrimaryEmail,
     UserUpdateSecondaryEmails,
 )
+from chafan_core.app.services import answers as answers_service
+from chafan_core.app.services import articles as articles_service
 from chafan_core.app.services import people as people_service
+from chafan_core.app.services import questions as questions_service
 from chafan_core.app.services import sites as sites_service
 from chafan_core.app.services import submissions as submissions_service
 from chafan_core.utils.base import HTTPException_
@@ -313,9 +316,7 @@ def list_my_article_columns(ctx) -> List[schemas.ArticleColumn]:
 
 
 def get_question_subscription(ctx, *, uuid: str) -> schemas.UserQuestionSubscription:
-    from chafan_core.app.services import questions as questions_service
-
-    question = questions_service.get_question_model_http(ctx.get_db(), uuid)
+    question = questions_service.get_readable_question_http(ctx, uuid)
     return questions_service.get_question_subscription(ctx, question)
 
 
@@ -333,12 +334,7 @@ def list_subscribed_questions(
 def subscribe_question(ctx, *, uuid: str) -> schemas.UserQuestionSubscription:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    question = crud.question.get_by_uuid(db, uuid=uuid)
-    if question is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The question doesn't exist in the system.",
-        )
+    question = questions_service.get_readable_question_http(ctx, uuid)
     current_user = crud.user.subscribe_question(
         db, db_obj=current_user, question=question
     )
@@ -352,12 +348,7 @@ def subscribe_question(ctx, *, uuid: str) -> schemas.UserQuestionSubscription:
 def unsubscribe_question(ctx, *, uuid: str) -> schemas.UserQuestionSubscription:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    question = crud.question.get_by_uuid(db, uuid=uuid)
-    if question is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The question doesn't exist in the system.",
-        )
+    question = questions_service.get_readable_question_http(ctx, uuid)
     current_user = crud.user.unsubscribe_question(
         db, db_obj=current_user, question=question
     )
@@ -372,13 +363,7 @@ def get_submission_subscription(
     ctx, *, uuid: str
 ) -> schemas.UserSubmissionSubscription:
     current_user = ctx.get_current_active_user()
-    db = ctx.get_db()
-    submission = crud.submission.get_by_uuid(db, uuid=uuid)
-    if submission is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The submission doesn't exist in the system.",
-        )
+    submission = submissions_service.get_readable_submission_http(ctx, uuid)
     return schemas.UserSubmissionSubscription(
         submission_uuid=submission.uuid,
         subscription_count=submission.subscribers.count(),
@@ -399,12 +384,7 @@ def list_subscribed_submissions(
 def subscribe_submission(ctx, *, uuid: str) -> schemas.UserSubmissionSubscription:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    submission = crud.submission.get_by_uuid(db, uuid=uuid)
-    if submission is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The submission doesn't exist in the system.",
-        )
+    submission = submissions_service.get_readable_submission_http(ctx, uuid)
     current_user = crud.user.subscribe_submission(
         db, db_obj=current_user, submission=submission
     )
@@ -418,12 +398,7 @@ def subscribe_submission(ctx, *, uuid: str) -> schemas.UserSubmissionSubscriptio
 def unsubscribe_submission(ctx, *, uuid: str) -> schemas.UserSubmissionSubscription:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    submission = crud.submission.get_by_uuid(db, uuid=uuid)
-    if submission is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The submission doesn't exist in the system.",
-        )
+    submission = submissions_service.get_readable_submission_http(ctx, uuid)
     current_user = crud.user.unsubscribe_submission(
         db, db_obj=current_user, submission=submission
     )
@@ -448,12 +423,7 @@ def list_bookmarked_answers(
 def bookmark_answer(ctx, *, uuid: str) -> schemas.UserAnswerBookmark:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    answer = crud.answer.get_by_uuid(db, uuid=uuid)
-    if answer is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The answer doesn't exist in the system.",
-        )
+    answer = answers_service.get_readable_answer_http(ctx, uuid)
     current_user = crud.user.bookmark_answer(db, db_obj=current_user, answer=answer)
     return schemas.UserAnswerBookmark(
         answer_uuid=answer.uuid,
@@ -465,12 +435,7 @@ def bookmark_answer(ctx, *, uuid: str) -> schemas.UserAnswerBookmark:
 def unbookmark_answer(ctx, *, uuid: str) -> schemas.UserAnswerBookmark:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    answer = crud.answer.get_by_uuid(db, uuid=uuid)
-    if answer is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The answer doesn't exist in the system.",
-        )
+    answer = answers_service.get_readable_answer_http(ctx, uuid)
     current_user = crud.user.unbookmark_answer(db, db_obj=current_user, answer=answer)
     return schemas.UserAnswerBookmark(
         answer_uuid=answer.uuid,
@@ -493,12 +458,7 @@ def list_bookmarked_articles(
 def bookmark_article(ctx, *, uuid: str) -> schemas.UserArticleBookmark:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    article = crud.article.get_by_uuid(db, uuid=uuid)
-    if article is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The article doesn't exist in the system.",
-        )
+    article = articles_service.get_readable_article_preview_http(ctx, uuid)
     current_user = crud.user.bookmark_article(db, db_obj=current_user, article=article)
     return schemas.UserArticleBookmark(
         article_uuid=article.uuid,
@@ -510,12 +470,7 @@ def bookmark_article(ctx, *, uuid: str) -> schemas.UserArticleBookmark:
 def unbookmark_article(ctx, *, uuid: str) -> schemas.UserArticleBookmark:
     current_user = ctx.get_current_active_user()
     db = ctx.get_db()
-    article = crud.article.get_by_uuid(db, uuid=uuid)
-    if article is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The article doesn't exist in the system.",
-        )
+    article = articles_service.get_readable_article_preview_http(ctx, uuid)
     current_user = crud.user.unbookmark_article(
         db, db_obj=current_user, article=article
     )

--- a/chafan_core/app/services/submissions.py
+++ b/chafan_core/app/services/submissions.py
@@ -26,6 +26,28 @@ def submission_schema(ctx, submission: models.Submission):
     return responders.submission.submission_schema_from_orm(ctx, submission)
 
 
+def get_readable_submission_http(ctx, uuid: str) -> models.Submission:
+    """Fetch submission if the principal may read it, else raise 400.
+
+    The read gate for every submission-scoped endpoint. Anything derived from a
+    submission (subscriptions, ...) must go through here so it can never end up
+    more permissive than the submission itself.
+    """
+    submission = crud.submission.get_by_uuid(ctx.get_db(), uuid=uuid)
+    if submission is None:
+        raise HTTPException_(
+            status_code=400,
+            detail="The submission doesn't exist in the system.",
+        )
+    check_user_in_site(
+        ctx.get_db(),
+        site=submission.site,
+        user_id=ctx.unwrapped_principal_id(),
+        op_type=OperationType.ReadSite,
+    )
+    return submission
+
+
 def recent_k_of_site(ctx, site: models.Site, k: int) -> List[schemas.Submission]:
     return filter_not_none(
         [submission_schema(ctx, s) for s in site.submissions]

--- a/chafan_core/tests/app/api/api_v1/test_me.py
+++ b/chafan_core/tests/app/api/api_v1/test_me.py
@@ -1,0 +1,391 @@
+"""Read gates on /me subscription and bookmark routes.
+
+services/me.py fetched every subscribe/bookmark target with a bare
+crud.<resource>.get_by_uuid and 400'd only when the row was missing, so an
+authenticated non-member of a private site could subscribe to or bookmark
+content there and read back its subscriber/bookmarker count. The read gates
+live inside the responders, and these routes build a small UserXSubscription
+schema instead of the full one, so they never reached them -- exactly the miss
+get_readable_question_http's docstring warns about.
+
+Every negative test below carries a control assertion that the outsider cannot
+read the resource directly, so a test can never pass merely because the
+fixture site stopped being private.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from chafan_core.app import crud
+from chafan_core.app.config import settings
+from chafan_core.tests.conftest import ensure_user_has_coins, ensure_user_in_site
+from chafan_core.tests.utils.user import authentication_token_from_email
+from chafan_core.tests.utils.utils import random_email, random_lower_string
+from chafan_core.utils.base import get_uuid
+
+
+@pytest.fixture(scope="module")
+def outsider_token_headers(client: TestClient, db: Session) -> dict:
+    """An authenticated user who is not a member of example_site_uuid."""
+    return authentication_token_from_email(
+        client=client, email=random_email(), db=db
+    )
+
+
+@pytest.fixture(scope="module")
+def private_site_answer_uuid(
+    client: TestClient,
+    db: Session,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_authored_question_uuid: str,
+) -> str:
+    """An answer by normal_user on a question in the private example site."""
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    body = f"Answer {random_lower_string()}"
+    r = client.post(
+        f"{settings.API_V1_STR}/answers/",
+        headers=normal_user_token_headers,
+        json={
+            "question_uuid": normal_user_authored_question_uuid,
+            "content": {
+                "source": body,
+                "rendered_text": body,
+                "editor": "markdown",
+            },
+            "is_published": True,
+            "is_autosaved": False,
+            "visibility": "anyone",
+            "writing_session_uuid": get_uuid(),
+        },
+    )
+    r.raise_for_status()
+    return r.json()["uuid"]
+
+
+@pytest.fixture(scope="module")
+def draft_article_uuid(
+    client: TestClient,
+    db: Session,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    example_article_column_uuid: str,
+) -> str:
+    """An unpublished article by normal_user: readable only by its author.
+
+    Every other article fixture uses visibility "anyone" and is published, so
+    the preview gate is never exercised by them.
+    """
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/",
+        headers=normal_user_token_headers,
+        json={
+            "title": f"Draft Article ({random_lower_string()})",
+            "content": {"source": "Draft body.", "editor": "tiptap"},
+            "article_column_uuid": example_article_column_uuid,
+            "is_published": False,
+            "writing_session_uuid": get_uuid(),
+            "visibility": "anyone",
+        },
+    )
+    r.raise_for_status()
+    return r.json()["uuid"]
+
+
+def _assert_blocked(r, what: str) -> None:
+    assert r.status_code != 200, f"outsider was allowed to {what}: {r.text}"
+    assert r.status_code in (400, 401, 403, 404), r.text
+
+
+# =============================================================================
+# Question subscriptions
+# =============================================================================
+
+
+def test_question_subscription_routes_reject_non_member(
+    client: TestClient,
+    db: Session,
+    outsider_token_headers: dict,
+    normal_user_authored_question_uuid: str,
+) -> None:
+    """A non-member can neither subscribe, unsubscribe, nor read the count."""
+    uuid = normal_user_authored_question_uuid
+
+    # Control: the private-site question is genuinely unreadable to them.
+    control = client.get(
+        f"{settings.API_V1_STR}/questions/{uuid}", headers=outsider_token_headers
+    )
+    assert control.status_code != 200, (
+        "fixture site is not private; the assertions below would be vacuous"
+    )
+
+    _assert_blocked(
+        client.post(
+            f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "subscribe to a private-site question",
+    )
+    _assert_blocked(
+        client.get(
+            f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "read the subscriber count of a private-site question",
+    )
+    _assert_blocked(
+        client.delete(
+            f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "unsubscribe from a private-site question",
+    )
+
+
+def test_rejected_question_subscribe_writes_no_row(
+    client: TestClient,
+    db: Session,
+    outsider_token_headers: dict,
+    normal_user_authored_question_uuid: str,
+) -> None:
+    """The blocked subscribe must not leave a durable subscription."""
+    uuid = normal_user_authored_question_uuid
+    outsider_uuid = client.get(
+        f"{settings.API_V1_STR}/me", headers=outsider_token_headers
+    ).json()["uuid"]
+
+    client.post(
+        f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+        headers=outsider_token_headers,
+    )
+
+    db.expire_all()
+    question = crud.question.get_by_uuid(db, uuid=uuid)
+    assert question is not None
+    subscriber_uuids = [u.uuid for u in question.subscribers]
+    assert outsider_uuid not in subscriber_uuids
+
+
+def test_question_subscription_still_works_for_member(
+    client: TestClient,
+    db: Session,
+    superuser_token_headers: dict,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    normal_user_uuid: str,
+    example_site_uuid: str,
+    normal_user_authored_question_uuid: str,
+) -> None:
+    """Happy path is unchanged: a site member can still subscribe."""
+    ensure_user_in_site(
+        client, db, normal_user_id, normal_user_uuid,
+        example_site_uuid, superuser_token_headers
+    )
+    uuid = normal_user_authored_question_uuid
+
+    r = client.post(
+        f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["subscribed_by_me"] is True
+
+    r = client.get(
+        f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/me/question-subscriptions/{uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["subscribed_by_me"] is False
+
+
+# =============================================================================
+# Submission subscriptions
+# =============================================================================
+
+
+def test_submission_subscription_routes_reject_non_member(
+    client: TestClient,
+    outsider_token_headers: dict,
+    example_submission_uuid: str,
+) -> None:
+    uuid = example_submission_uuid
+
+    control = client.get(
+        f"{settings.API_V1_STR}/submissions/{uuid}", headers=outsider_token_headers
+    )
+    assert control.status_code != 200, (
+        "fixture site is not private; the assertions below would be vacuous"
+    )
+
+    _assert_blocked(
+        client.post(
+            f"{settings.API_V1_STR}/me/submission-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "subscribe to a private-site submission",
+    )
+    _assert_blocked(
+        client.get(
+            f"{settings.API_V1_STR}/me/submission-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "read the subscriber count of a private-site submission",
+    )
+    _assert_blocked(
+        client.delete(
+            f"{settings.API_V1_STR}/me/submission-subscriptions/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "unsubscribe from a private-site submission",
+    )
+
+
+def test_submission_subscription_still_works_for_member(
+    client: TestClient,
+    normal_user_token_headers: dict,
+    example_submission_uuid: str,
+) -> None:
+    r = client.post(
+        f"{settings.API_V1_STR}/me/submission-subscriptions/{example_submission_uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["subscribed_by_me"] is True
+
+
+# =============================================================================
+# Answer bookmarks
+# =============================================================================
+
+
+def test_answer_bookmark_routes_reject_non_member(
+    client: TestClient,
+    outsider_token_headers: dict,
+    private_site_answer_uuid: str,
+) -> None:
+    uuid = private_site_answer_uuid
+
+    control = client.get(
+        f"{settings.API_V1_STR}/answers/{uuid}", headers=outsider_token_headers
+    )
+    assert control.status_code != 200, (
+        "fixture site is not private; the assertions below would be vacuous"
+    )
+
+    _assert_blocked(
+        client.post(
+            f"{settings.API_V1_STR}/me/answer-bookmarks/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "bookmark a private-site answer",
+    )
+    _assert_blocked(
+        client.delete(
+            f"{settings.API_V1_STR}/me/answer-bookmarks/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "unbookmark a private-site answer",
+    )
+
+
+def test_answer_bookmark_still_works_for_member(
+    client: TestClient,
+    normal_user_token_headers: dict,
+    private_site_answer_uuid: str,
+) -> None:
+    r = client.post(
+        f"{settings.API_V1_STR}/me/answer-bookmarks/{private_site_answer_uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["bookmarked_by_me"] is True
+
+
+# =============================================================================
+# Article bookmarks
+# =============================================================================
+
+
+def test_article_bookmark_rejects_non_author_draft(
+    client: TestClient,
+    outsider_token_headers: dict,
+    draft_article_uuid: str,
+) -> None:
+    """An unpublished article is readable only by its author."""
+    uuid = draft_article_uuid
+
+    control = client.get(
+        f"{settings.API_V1_STR}/articles/{uuid}", headers=outsider_token_headers
+    )
+    assert control.status_code != 200, (
+        "draft article is readable by a non-author; assertions would be vacuous"
+    )
+
+    _assert_blocked(
+        client.post(
+            f"{settings.API_V1_STR}/me/article-bookmarks/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "bookmark another author's draft article",
+    )
+    _assert_blocked(
+        client.delete(
+            f"{settings.API_V1_STR}/me/article-bookmarks/{uuid}",
+            headers=outsider_token_headers,
+        ),
+        "unbookmark another author's draft article",
+    )
+
+
+def test_article_bookmark_still_works_for_published_article(
+    client: TestClient,
+    normal_user_token_headers: dict,
+    example_article_uuid: str,
+) -> None:
+    r = client.post(
+        f"{settings.API_V1_STR}/me/article-bookmarks/{example_article_uuid}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["bookmarked_by_me"] is True
+
+
+# =============================================================================
+# Topics: deliberately ungated
+# =============================================================================
+
+
+def test_topic_subscription_is_not_site_scoped(
+    client: TestClient,
+    db: Session,
+    outsider_token_headers: dict,
+) -> None:
+    """Topics carry no site and no visibility, so they stay ungated.
+
+    Pinned so the gates added for the site-scoped resources are not extended
+    here by analogy: there is nothing to leak.
+    """
+    topic_name = f"topic {random_lower_string()[:8]}"
+    r = client.post(
+        f"{settings.API_V1_STR}/topics/",
+        headers=outsider_token_headers,
+        json={"name": topic_name},
+    )
+    if r.status_code != 200:
+        pytest.skip(f"topic creation unavailable: {r.status_code}")
+    topic_uuid = r.json()["uuid"]
+
+    r = client.post(
+        f"{settings.API_V1_STR}/me/topic-subscriptions/{topic_uuid}",
+        headers=outsider_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["subscribed_by_me"] is True


### PR DESCRIPTION
## The bug

`services/me.py` fetched every subscribe/bookmark target with a bare `crud.<resource>.get_by_uuid` and 400'd only when the row was **missing**. No read gate ran. An authenticated non-member of a private site could therefore subscribe to, or bookmark, content in that site — and read back its subscriber / bookmarker count from the response body.

Private sites exist in production (design decision D3 in the target-architecture doc), so this is a live authorization hole, not tech debt.

Why it was missed: the read gates live inside the responders, and these routes build a small `UserXSubscription` / `UserXBookmark` schema instead of the full one, so they never reached them — exactly the miss that `get_readable_question_http`'s docstring warns about.

## The fix

One read gate per resource, modelled on the existing `services.questions.get_readable_question_http`:

| helper | gate |
|---|---|
| `services.submissions.get_readable_submission_http` | site membership |
| `services.answers.get_readable_answer_http` | `answer_read_allowed` |
| `services.articles.get_readable_article_preview_http` | `article_preview_read_allowed` |

All ten `/me` subscribe/unsubscribe/bookmark/unbookmark entry points route through them. `get_question_subscription` moves off the ungated `get_question_model_http` onto `get_readable_question_http`.

Two deliberate choices:

- **Articles gate on `article_preview_read_allowed`, not `article_read_allowed`** — bookmarking does not hand back the body.
- **A denied read reports `"doesn't exist"` (400), not 403.** Both gates fold in site membership / publication state, so a distinguishable status would itself tell a stranger that the resource exists. This matches the site-membership branch of `get_readable_question_http`.

**Topic subscriptions are deliberately left ungated** — topics carry no site and no visibility, so there is nothing to leak. Pinned by a test so the gates are not extended there by analogy.

## Verification

`chafan_core/tests/app/api/api_v1/test_me.py` is included and **fails on the parent commit**: five tests 200'd where they must not. For example an outsider subscribing to a private-site question got back `{"question_uuid": "...", "subscription_count": 2, "subscribed_by_me": true}`.

Every negative test carries a control assertion that the outsider cannot read the resource directly, so none can pass merely because a fixture site stopped being private.

- `test_me.py` — 10 passed (5 failed before)
- `chafan_core/tests/app/api/` — 92 passed, 9 skipped
- `crud/` + `test_user_permission.py` + `test_feed.py` + `test_search.py` — 321 passed
- Both architecture ratchets: 0 errors
- **OpenAPI spec byte-identical to `main`** — no front-end change required

🤖 Generated with [Claude Code](https://claude.com/claude-code)