### PR TITLE
Thin endpoints/people.py to parse -> service -> schema (Step 4.2)

### DIFF
--- a/chafan_core/app/api/api_v1/endpoints/people.py
+++ b/chafan_core/app/api/api_v1/endpoints/people.py
@@ -1,25 +1,13 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends
 from fastapi.param_functions import Query
-from pydantic.tools import parse_obj_as
-from sqlalchemy.orm import Session
 
-from chafan_core.app import crud, models, schemas
+from chafan_core.app import schemas
 from chafan_core.app.api import deps
-from chafan_core.app.services import submissions as submissions_service
-from chafan_core.app.services import people as people_service
+from chafan_core.app.common import get_logger
 from chafan_core.app.infra.request_context import RequestContext
-from chafan_core.app.common import OperationType, get_logger
-from chafan_core.app.user_permission import user_in_site
-from chafan_core.app.model_utils import is_live_answer, is_live_article
-from chafan_core.app.schemas.richtext import RichText
-from chafan_core.app.schemas.user import (
-    UserEducationExperienceInternal,
-    UserWorkExperienceInternal,
-    YearContributions,
-)
-from chafan_core.utils.base import HTTPException_, filter_not_none, unwrap
+from chafan_core.app.services import people as people_service
 from chafan_core.utils.constants import (
     MAX_USER_ANSWERS_PAGINATION_LIMIT,
     MAX_USER_ARTICLES_PAGINATION_LIMIT,
@@ -33,114 +21,14 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
-def _get_work_exps(db: Session, user: models.User) -> List[schemas.UserWorkExperience]:
-    work_exps: List[UserWorkExperienceInternal] = []
-    if user.work_experiences is not None:
-        work_exps = parse_obj_as(
-            List[UserWorkExperienceInternal], user.work_experiences
-        )
-    ret = []
-    for work_exp in work_exps:
-        company_topic = crud.topic.get_by_uuid(db, uuid=work_exp.company_topic_uuid)
-        position_topic = crud.topic.get_by_uuid(db, uuid=work_exp.position_topic_uuid)
-        ret.append(
-            schemas.UserWorkExperience(
-                company_topic=schemas.Topic.from_orm(company_topic),
-                position_topic=schemas.Topic.from_orm(position_topic),
-            )
-        )
-    return ret
-
-
-def _get_edu_exps(
-    db: Session, user: models.User
-) -> List[schemas.UserEducationExperience]:
-    edu_exps: List[UserEducationExperienceInternal] = []
-    if user.education_experiences is not None:
-        edu_exps = parse_obj_as(
-            List[UserEducationExperienceInternal], user.education_experiences
-        )
-    ret = []
-    for edu_exp in edu_exps:
-        school_topic = crud.topic.get_by_uuid(db, uuid=edu_exp.school_topic_uuid)
-        ret.append(
-            schemas.UserEducationExperience(
-                school_topic=schemas.Topic.from_orm(school_topic),
-                level=edu_exp.level_name,
-                major=edu_exp.major,
-                enroll_year=edu_exp.enroll_year,
-                graduate_year=edu_exp.graduate_year,
-            )
-        )
-    return ret
-
-
-def _get_user_public(
-    ctx: RequestContext, user: models.User, view_times: int
-) -> schemas.UserPublic:
-    """One public profile schema for any principal allowed to view the user."""
-    preview = ctx.preview_of_user(user)
-    db = ctx.get_db()
-    about_content = None
-    if user.about is not None:
-        about_content = RichText(source=user.about, editor="wysiwyg")
-    contributions = [
-        YearContributions(year=year, data=data)
-        for year, data in ctx.get_user_contributions(user)
-    ]
-    return schemas.UserPublic(
-        **preview.dict(),
-        gif_avatar_url=user.gif_avatar_url,
-        answers_count=len(
-            [answer for answer in user.answers if is_live_answer(answer)]
-        ),
-        submissions_count=len(
-            [submission for submission in user.submissions if not submission.is_hidden]
-        ),
-        questions_count=len(
-            [question for question in user.questions if not question.is_hidden]
-        ),
-        articles_count=len(
-            [article for article in user.articles if is_live_article(article)]
-        ),
-        created_at=user.created_at,
-        profile_view_times=view_times,
-        about_content=about_content,
-        profiles=[],
-        residency_topics=[schemas.Topic.from_orm(t) for t in user.residency_topics],
-        profession_topics=[schemas.Topic.from_orm(t) for t in user.profession_topics],
-        github_username=user.github_username,
-        twitter_username=user.twitter_username,
-        linkedin_url=user.linkedin_url,
-        homepage_url=user.homepage_url,
-        zhihu_url=user.zhihu_url,
-        subscribed_topics=[schemas.Topic.from_orm(t) for t in user.subscribed_topics],
-        work_exps=_get_work_exps(db, user),
-        edu_exps=_get_edu_exps(db, user),
-        contributions=contributions,
-    )
-
-
 @router.get("/{handle}", response_model=schemas.UserPublic)
 def get_user_public(
     *,
     ctx: RequestContext = Depends(deps.get_request_context),
     handle: StrippedNonEmptyBasicStr,
-    current_user_id: Optional[int] = Depends(deps.try_get_current_user_id),
 ) -> Any:
     logger.debug("Call get_user_public")
-    db = ctx.get_db()
-    user = crud.user.get_by_handle(db, handle=handle)
-    if user is None or not user.is_active:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    # TODO turn it off 2025-07-23
-    view_times = 5  # view_counters.get_views(user.uuid, "profile")
-    if current_user_id is not None:
-        db.commit()
-    return _get_user_public(ctx, user, view_times)
+    return people_service.get_user_public(ctx, handle=handle)
 
 
 @router.get("/{uuid}/site-profiles/", response_model=List[schemas.Profile])
@@ -170,9 +58,7 @@ def get_user_questions(
     """
     Get a user's asked questions.
     """
-    return people_service.list_user_questions(
-        ctx, uuid=uuid, skip=skip, limit=limit
-    )
+    return people_service.list_user_questions(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get("/{uuid}/submissions/", response_model=List[schemas.Submission])
@@ -190,19 +76,7 @@ def get_user_submissions(
     """
     Get a user's submissions.
     """
-    user = crud.user.get_by_uuid(ctx.get_db(), uuid=uuid)
-    if user is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return filter_not_none(
-        [
-            #submissions_service.submission_schema(ctx, submission)
-            submissions_service.submission_schema(ctx, submission)
-            for submission in user.submissions
-        ]
-    )[skip : skip + limit]
+    return people_service.list_user_submissions(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get("/{uuid}/articles/", response_model=List[schemas.ArticlePreview])
@@ -217,9 +91,7 @@ def get_user_articles(
         gt=0,
     ),
 ) -> Any:
-    return people_service.list_user_articles(
-        ctx, uuid=uuid, skip=skip, limit=limit
-    )
+    return people_service.list_user_articles(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get(
@@ -240,45 +112,25 @@ def get_user_answers(
     """
     Get a user's authored answers.
     """
-    author = crud.user.get_by_uuid(ctx.get_db(), uuid=uuid)
-    if author is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return people_service.get_authored_answers_for_principal(ctx, author)[skip : skip + limit]
+    return people_service.list_user_answers(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get("/{uuid}/work-exps/", response_model=List[schemas.UserWorkExperience])
 def get_user_work_exps(
     *,
-    db: Session = Depends(deps.get_db),
+    ctx: RequestContext = Depends(deps.get_request_context_logged_in),
     uuid: str,
-    current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
-    user = crud.user.get_by_uuid(db, uuid=uuid)
-    if user is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return _get_work_exps(db, user)
+    return people_service.list_user_work_exps(ctx, uuid=uuid)
 
 
 @router.get("/{uuid}/edu-exps/", response_model=List[schemas.UserEducationExperience])
 def get_user_edu_exps(
     *,
-    db: Session = Depends(deps.get_db),
+    ctx: RequestContext = Depends(deps.get_request_context_logged_in),
     uuid: str,
-    current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
-    user = crud.user.get_by_uuid(db, uuid=uuid)
-    if user is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return _get_edu_exps(db, user)
+    return people_service.list_user_edu_exps(ctx, uuid=uuid)
 
 
 @router.get("/{uuid}/followers/", response_model=List[schemas.UserPreview])
@@ -293,13 +145,7 @@ def get_user_followers(
         gt=0,
     ),
 ) -> Any:
-    user = crud.user.get_by_uuid(ctx.get_db(), uuid=uuid)
-    if user is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return people_service.get_followers(ctx, user, skip=skip, limit=limit)
+    return people_service.list_user_followers(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get("/{uuid}/followed/", response_model=List[schemas.UserPreview])
@@ -314,13 +160,7 @@ def get_user_followed(
         gt=0,
     ),
 ) -> Any:
-    user = crud.user.get_by_uuid(ctx.get_db(), uuid=uuid)
-    if user is None:
-        raise HTTPException_(
-            status_code=400,
-            detail="The user doesn't exist in the system.",
-        )
-    return people_service.get_followed(ctx, user, skip=skip, limit=limit)
+    return people_service.list_user_followed(ctx, uuid=uuid, skip=skip, limit=limit)
 
 
 @router.get("/{uuid}/related/", response_model=List[schemas.UserPreview])
@@ -329,5 +169,4 @@ def get_related(
     ctx: RequestContext = Depends(deps.get_request_context_logged_in),
     uuid: str,
 ) -> Any:
-    target_user = unwrap(crud.user.get_by_uuid(ctx.get_db(), uuid=uuid))
-    return people_service.get_related_users(ctx, target_user)
+    return people_service.list_related_users(ctx, uuid=uuid)

--- a/chafan_core/app/services/people.py
+++ b/chafan_core/app/services/people.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional
 
+from pydantic.tools import parse_obj_as
+from sqlalchemy.orm import Session
+
 from chafan_core.app import crud, models, schemas
 from chafan_core.app.common import OperationType
+from chafan_core.app.model_utils import is_live_answer, is_live_article
 from chafan_core.app.recs import matrices as recs_matrices
 from chafan_core.app.responders import misc as misc_responder
 from chafan_core.app.schemas.preview import UserPreview
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.app.schemas.user import (
+    UserEducationExperienceInternal,
+    UserWorkExperienceInternal,
+    YearContributions,
+)
+from chafan_core.app.services import submissions as submissions_service
 from chafan_core.app.user_permission import user_in_site
 from chafan_core.utils.base import EntityType, HTTPException_, filter_not_none, unwrap
 
@@ -109,6 +120,112 @@ def list_user_site_profiles(
     ]
 
 
+def _work_exps(db: Session, user: models.User) -> List[schemas.UserWorkExperience]:
+    work_exps: List[UserWorkExperienceInternal] = []
+    if user.work_experiences is not None:
+        work_exps = parse_obj_as(
+            List[UserWorkExperienceInternal], user.work_experiences
+        )
+    ret = []
+    for work_exp in work_exps:
+        company_topic = crud.topic.get_by_uuid(db, uuid=work_exp.company_topic_uuid)
+        position_topic = crud.topic.get_by_uuid(db, uuid=work_exp.position_topic_uuid)
+        ret.append(
+            schemas.UserWorkExperience(
+                company_topic=schemas.Topic.from_orm(company_topic),
+                position_topic=schemas.Topic.from_orm(position_topic),
+            )
+        )
+    return ret
+
+
+def _edu_exps(db: Session, user: models.User) -> List[schemas.UserEducationExperience]:
+    edu_exps: List[UserEducationExperienceInternal] = []
+    if user.education_experiences is not None:
+        edu_exps = parse_obj_as(
+            List[UserEducationExperienceInternal], user.education_experiences
+        )
+    ret = []
+    for edu_exp in edu_exps:
+        school_topic = crud.topic.get_by_uuid(db, uuid=edu_exp.school_topic_uuid)
+        ret.append(
+            schemas.UserEducationExperience(
+                school_topic=schemas.Topic.from_orm(school_topic),
+                level=edu_exp.level_name,
+                major=edu_exp.major,
+                enroll_year=edu_exp.enroll_year,
+                graduate_year=edu_exp.graduate_year,
+            )
+        )
+    return ret
+
+
+def _user_public_schema(
+    ctx, user: models.User, view_times: int
+) -> schemas.UserPublic:
+    """One public profile schema for any principal allowed to view the user."""
+    preview = preview_of_user(ctx, user)
+    db = ctx.get_db()
+    about_content = None
+    if user.about is not None:
+        about_content = RichText(source=user.about, editor="wysiwyg")
+    contributions = [
+        YearContributions(year=year, data=data)
+        for year, data in ctx.get_user_contributions(user)
+    ]
+    return schemas.UserPublic(
+        **preview.dict(),
+        gif_avatar_url=user.gif_avatar_url,
+        answers_count=len(
+            [answer for answer in user.answers if is_live_answer(answer)]
+        ),
+        submissions_count=len(
+            [submission for submission in user.submissions if not submission.is_hidden]
+        ),
+        questions_count=len(
+            [question for question in user.questions if not question.is_hidden]
+        ),
+        articles_count=len(
+            [article for article in user.articles if is_live_article(article)]
+        ),
+        created_at=user.created_at,
+        profile_view_times=view_times,
+        about_content=about_content,
+        profiles=[],
+        residency_topics=[schemas.Topic.from_orm(t) for t in user.residency_topics],
+        profession_topics=[schemas.Topic.from_orm(t) for t in user.profession_topics],
+        github_username=user.github_username,
+        twitter_username=user.twitter_username,
+        linkedin_url=user.linkedin_url,
+        homepage_url=user.homepage_url,
+        zhihu_url=user.zhihu_url,
+        subscribed_topics=[schemas.Topic.from_orm(t) for t in user.subscribed_topics],
+        work_exps=_work_exps(db, user),
+        edu_exps=_edu_exps(db, user),
+        contributions=contributions,
+    )
+
+
+def get_user_public(ctx, *, handle: str) -> schemas.UserPublic:
+    user = crud.user.get_by_handle(ctx.get_db(), handle=handle)
+    if user is None or not user.is_active:
+        raise HTTPException_(
+            status_code=400,
+            detail="The user doesn't exist in the system.",
+        )
+    # TODO turn it off 2025-07-23
+    view_times = 5  # view_counters.get_views(user.uuid, "profile")
+    return _user_public_schema(ctx, user, view_times)
+
+
+def list_user_work_exps(ctx, *, uuid: str) -> List[schemas.UserWorkExperience]:
+    return _work_exps(ctx.get_db(), _require_user(ctx, uuid))
+
+
+def list_user_edu_exps(ctx, *, uuid: str) -> List[schemas.UserEducationExperience]:
+    return _edu_exps(ctx.get_db(), _require_user(ctx, uuid))
+
+
 def list_user_questions(
     ctx, *, uuid: str, skip: int, limit: int
 ) -> List[schemas.QuestionPreview]:
@@ -133,6 +250,41 @@ def list_user_articles(
     return filter_not_none(
         [mat.preview_of_article(article) for article in user.articles]
     )[skip : skip + limit]
+
+
+def list_user_submissions(
+    ctx, *, uuid: str, skip: int, limit: int
+) -> List[schemas.Submission]:
+    user = _require_user(ctx, uuid)
+    return filter_not_none(
+        [
+            submissions_service.submission_schema(ctx, submission)
+            for submission in user.submissions
+        ]
+    )[skip : skip + limit]
+
+
+def list_user_answers(
+    ctx, *, uuid: str, skip: int, limit: int
+) -> List[schemas.AnswerPreview]:
+    author = _require_user(ctx, uuid)
+    return get_authored_answers_for_principal(ctx, author)[skip : skip + limit]
+
+
+def list_user_followers(
+    ctx, *, uuid: str, skip: int, limit: int
+) -> List[UserPreview]:
+    return get_followers(ctx, _require_user(ctx, uuid), skip=skip, limit=limit)
+
+
+def list_user_followed(
+    ctx, *, uuid: str, skip: int, limit: int
+) -> List[UserPreview]:
+    return get_followed(ctx, _require_user(ctx, uuid), skip=skip, limit=limit)
+
+
+def list_related_users(ctx, *, uuid: str) -> List[UserPreview]:
+    return get_related_users(ctx, unwrap(crud.user.get_by_uuid(ctx.get_db(), uuid=uuid)))
 
 
 def get_related_users(ctx, target_user: models.User) -> List[UserPreview]:

--- a/scripts/static_analysis/check_layer_imports.py
+++ b/scripts/static_analysis/check_layer_imports.py
@@ -105,7 +105,6 @@ def main() -> int:
                 # Temporary allowlist: large auth/profile modules still mid-migration.
                 allow = {
                     "chafan_core/app/api/api_v1/endpoints/login.py",
-                    "chafan_core/app/api/api_v1/endpoints/people.py",
                 }
                 msg = f"{rel}:{lineno}: api must not import {mod}"
                 if str(rel) in allow:

--- a/scripts/static_analysis/check_service_commits.py
+++ b/scripts/static_analysis/check_service_commits.py
@@ -41,10 +41,9 @@ BOUNDARY_FILES = {
 # Files permitted to keep a commit, keyed by path rather than path:line so a
 # moved line cannot silently re-arm the exemption. Must only ever shrink.
 ALLOWLIST: set[str] = {
-    # Mid-migration: the last endpoints holding business logic. Both also sit
-    # on check_layer_imports.py's allowlist; clearing them clears both.
+    # Mid-migration: the last endpoint holding business logic. It also sits
+    # on check_layer_imports.py's allowlist; clearing it clears both.
     "chafan_core/app/api/api_v1/endpoints/login.py",
-    "chafan_core/app/api/api_v1/endpoints/people.py",
 }
 
 


### PR DESCRIPTION
Step 4, item 2 of `docs/proposals/2026-07-15-target-architecture.md`, for `people.py`. One of the two remaining ratchet-allowlisted endpoints.

## What changed

**`api/api_v1/endpoints/people.py` (333 → 172 lines).** All 11 routes are now parse → resolve deps → one service call → return. It no longer imports `crud`, `models`, `responders`, `Session`, `parse_obj_as`, `RichText`, or the `*Internal` schemas — only `schemas`, `deps`, `RequestContext`, `services.people`, and constants.

**`services/people.py` (158 → 310 lines), extended rather than restructured.** The module already existed and already backed 7 routes. `_get_work_exps`, `_get_edu_exps` and `_get_user_public` move down verbatim, plus new uuid-taking entry points following the module's existing `list_user_*` convention. The pre-existing model-taking functions are untouched.

**Both ratchet scripts:** `people.py` removed from the allowlist. `login.py` entries left intact — it is the last one, handled separately.

## The `db.commit()` at line 142 was dead. Deleted.

It sat inside a `GET` handler, conditional on `current_user_id is not None`. Evidence from `git log -L`:

- Before `aa22c6a` ("Rewrite view count logic") the handler read `view_counters.add_view(user.uuid, "profile", current_user_id)` immediately followed by `db.commit()`. That commit commented the call out and left the commit behind. The write was its only subject.
- In current code the only statement between handler entry and the commit is `crud.user.get_by_handle`, a pure read; `view_times = 5` is a literal.
- `deps.get_request_context` commits at request end anyway.

This clears `people.py` from the commit ratchet, leaving `login.py` as the only remaining violation of the single-transaction-boundary rule (§1.3).

## Verification

**No test in the repo exercises any `/people/` route** (only `smoke/scenarios/s09_follow.py`, which is manual), so this was verified directly:

- **OpenAPI spec byte-identical to `main`** — all 11 `/people/` paths plus `components`. No front-end change required.
- A 48-case response capture across every route (anonymous + authenticated; valid and missing handle/uuid; pagination edges including `limit=0` → 422; work/edu experiences seeded so those branches returned non-empty payloads) — byte-identical.
- `chafan_core/tests/app/api/` — 82 passed, 9 skipped.
- Both architecture ratchets: 0 errors.

## Two inconsistencies preserved, not fixed

Flagging rather than silently changing:

1. **`services/people.py` has two calling conventions.** The `list_user_*` functions take `(ctx, *, uuid, ...)`; `get_followers`/`get_followed`/`get_related_users`/`preview_of_user` take a positional ORM model. New entry points follow the first; the second is left alone.
2. **`/related/` uses `unwrap()`** → `AssertionError` → 500 on a bad uuid, where every other route 400s via `_require_user`. Kept so the status code does not change, but someone should decide on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)