### PR TITLE
Fix inert rate limit on POST /password-recovery/{email}

### DIFF
--- a/chafan_core/app/api/api_v1/endpoints/login.py
+++ b/chafan_core/app/api/api_v1/endpoints/login.py
@@ -62,13 +62,13 @@ def login_with_verification_code_access_token(
     )
 
 
-# NOTE: @limiter.limit sits *above* @router.post here, so the router registered
-# the undecorated function and this limit never applies. Pre-existing; preserved
-# deliberately -- moving it would be a behavior change, not a refactor.
-@limiter.limit("1/minute")
 @router.post("/password-recovery/{email}", response_model=schemas.GenericResponse)
+@limiter.limit("1/minute")
 def recover_password(
-    request: Request, email: CaseInsensitiveEmailStr, db: Session = Depends(deps.get_db)
+    response: Response,
+    request: Request,
+    email: CaseInsensitiveEmailStr,
+    db: Session = Depends(deps.get_db),
 ) -> Any:
     """
     Password Recovery

--- a/chafan_core/tests/app/api/api_v1/test_login.py
+++ b/chafan_core/tests/app/api/api_v1/test_login.py
@@ -30,3 +30,45 @@ def test_reset_password_verify(client: TestClient) -> None:
     response = r.json()
     assert r.status_code == 200
     assert response["success"], response["msg"]
+
+
+def test_password_recovery_is_rate_limited(client: TestClient, monkeypatch) -> None:
+    """`@limiter.limit` must sit below `@router.post`, or it never applies.
+
+    Decorators apply bottom-up: with the limiter on top, `router.post` registers
+    the *undecorated* function and the rate-limited wrapper is never routed.
+    That left POST /password-recovery/{email} open to unauthenticated
+    password-reset email flooding against any address.
+
+    A second, independent defect had to be fixed alongside the decorator
+    order: the handler needs a `response: Response` parameter, because the
+    limiter runs with `headers_enabled=True` and slowapi injects the
+    `X-RateLimit-*` headers into it. Swapping the decorators alone turns the
+    inert limit into a 500 on every call, which this test also catches.
+
+    `client_ip` honours x-forwarded-for, so each run gets its own bucket rather
+    than depending on Redis state left by earlier tests.
+    """
+    from chafan_core.app.services import auth as auth_service
+
+    sent: list = []
+    monkeypatch.setattr(
+        auth_service,
+        "send_reset_password_email",
+        lambda **kwargs: sent.append(kwargs),
+    )
+
+    email = unwrap(settings.FIRST_SUPERUSER)
+    headers = {"X-Forwarded-For": f"198.51.100.{len(email) % 200 + 1}"}
+    url = f"{settings.API_V1_STR}/password-recovery/{email}"
+
+    first = client.post(url, headers=headers)
+    assert first.status_code == 200, first.text
+
+    second = client.post(url, headers=headers)
+    assert second.status_code == 429, (
+        f"second call returned {second.status_code}, not 429 -- the rate limit "
+        f"is inert; check that @limiter.limit sits below @router.post"
+    )
+
+    assert len(sent) == 1, "the rate-limited call must not send a second email"


### PR DESCRIPTION
**Security fix.** The `1/minute` rate limit on password recovery never applied, leaving the route open to unauthenticated password-reset email flooding against any address. Found while refactoring `login.py` (#163), which preserved the behavior verbatim so the fix could be reviewed on its own.

## Two independent defects — both had to be fixed

**1. Decorator order.** `@limiter.limit` sat *above* `@router.post`. Decorators apply bottom-up, so the router registered the **undecorated** function and the rate-limited wrapper was never routed. `/send-verification-code` carries the same two decorators in the opposite order and limits correctly.

**2. Missing `response: Response` parameter.** The limiter runs with `headers_enabled=True`, so slowapi needs somewhere to inject `X-RateLimit-*` headers; without it `_inject_headers` raises.

The second is the reason this isn't a one-line change. **Swapping the decorators alone does not fix the bug — it converts an inert limit into a 500 on every call.** I hit exactly that when I first tried the obvious fix.

## Evidence

Controlled comparison, one process, one IP, same `1/minute` limit — the only variable is decorator order:

| Route | Order | Calls 1–4 |
|---|---|---|
| `/password-recovery/{email}` | limiter **above** router | 500, 500, 500, 500 — handler reached every time |
| `/send-verification-code` | limiter **below** router | 500, **429, 429, 429** |

(The 500s are the test env having no SMTP host; what matters is whether the handler was reached at all.)

## The regression test distinguishes all three states

| State | Result |
|---|---|
| Original bug | fails: `second call returned 200, not 429` |
| Decorator swap only | fails: `parameter 'response' must be an instance of starlette.responses.Response` |
| Complete fix | **passes** |

It routes through `x-forwarded-for` so each run gets its own limiter bucket rather than depending on Redis state left by earlier tests, and asserts the rejected call sends no second email.

## Audit: this was the only affected route

An AST pass over all 17 rate-limited endpoints checks both properties — decorator order and the presence of a `response` parameter. Every other route already had both. `recover_password` was uniquely broken.

Worth considering as a follow-up: promoting that audit into `scripts/static_analysis/` alongside the existing ratchets, so the invariant is enforced rather than re-derived. It fits naturally with Step 4 item 7 (widening the ratchet). Left out here to keep a security fix small and reviewable.

## Verification

- Full suite: **425 passed, 9 skipped** (424 baseline + this test)
- Both ratchets: `lint.sh` exit 0
- **OpenAPI spec byte-identical to `main`** — FastAPI special-cases `Response` parameters, so adding one does not alter the published schema. No front-end change.

## Merge ordering

Independent of #163 — both touch the same decorator pair in `login.py`, so whichever lands second needs a trivial conflict resolution. #163 added an explanatory comment above the decorators noting the bug was preserved deliberately; **that comment should be deleted when this fix lands.** Merging this one first is slightly simpler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)