### PR TITLE
activity: consolidate per-verb event policy into one table

### DIFF
--- a/chafan_core/app/models/activity.py
+++ b/chafan_core/app/models/activity.py
@@ -10,6 +10,11 @@ if TYPE_CHECKING:
 
 
 class Activity(Base):
+    """A published event: what happened, and where it may be seen.
+
+    Subject-oriented, carries the payload. See docs/glossary.md.
+    """
+
     id = Column(Integer, primary_key=True, index=True)
     site_id = Column(Integer, ForeignKey("site.id"), index=True)
     site: Optional["Site"] = relationship("Site", foreign_keys=[site_id])  # type: ignore

--- a/chafan_core/app/models/feed.py
+++ b/chafan_core/app/models/feed.py
@@ -12,6 +12,11 @@ if TYPE_CHECKING:
 
 
 class Feed(Base):
+    """Delivery of one Activity to one receiver.
+
+    Receiver-oriented index, not a payload. See docs/glossary.md.
+    """
+
     id = Column(Integer, primary_key=True, index=True)
     receiver_id = Column(Integer, ForeignKey("user.id"), index=True, nullable=False)
     receiver = relationship("User", foreign_keys=[receiver_id])

--- a/chafan_core/app/models/notification.py
+++ b/chafan_core/app/models/notification.py
@@ -10,6 +10,12 @@ if TYPE_CHECKING:
 
 
 class Notification(Base):
+    """A directed delivery of one event to one receiver, with read state.
+
+    Re-serializes the event rather than referencing an Activity. See
+    docs/glossary.md.
+    """
+
     id = Column(Integer, primary_key=True, index=True)
     receiver_id = Column(Integer, ForeignKey("user.id"), nullable=False, index=True)
     receiver = relationship("User", back_populates="notifications")

--- a/chafan_core/app/responders/rss.py
+++ b/chafan_core/app/responders/rss.py
@@ -8,7 +8,8 @@ from chafan_core.app.config import settings
 import logging
 logger = logging.getLogger(__name__)
 
-def build_rss(activities: List, site)->str:
+def build_rss(contents: List, site)->str:
+    """Render content items -- Answers/Questions/Articles, not Activity rows."""
     fg = FeedGenerator()
     if site is not None:
         fg.title("ChaFan RSS " + site.name)
@@ -20,35 +21,34 @@ def build_rss(activities: List, site)->str:
         fg.link(href=f"{settings.SERVER_HOST}")
     fg.id("https://cha.fan/")
 
-    for ac in activities:
+    for content in contents:
         fe = fg.add_entry()
         verb = "内容"
-        user = ac.author.full_name
+        user = content.author.full_name
         if user is None or user == "":
             user ="茶饭用户"
         link = "https://cha.fan"
         description = "内容"
 
-        if isinstance(ac, Answer):
-            description = ac.body
+        if isinstance(content, Answer):
+            description = content.body
             verb = "回答"
-            answer = ac
-            question = ac.question
+            answer = content
+            question = content.question
             link = f"{settings.SERVER_HOST}/questions/{question.uuid}/answers/{answer.uuid}"
-        elif isinstance(ac, Question):
-            description = ac.title
+        elif isinstance(content, Question):
+            description = content.title
             verb = "提问"
-            question = ac
+            question = content
             link = f"{settings.SERVER_HOST}/questions/{question.uuid}"
-        elif isinstance(ac, Article):
-            print(ac.__dict__)
-            description = ac.title + "\n\n"
-            if ac.body_text is not None:
-                description = description + ac.body_text
-            verb = "文章 : " + ac.title
-            link = f"{settings.SERVER_HOST}/articles/{ac.uuid}"
+        elif isinstance(content, Article):
+            description = content.title + "\n\n"
+            if content.body_text is not None:
+                description = description + content.body_text
+            verb = "文章 : " + content.title
+            link = f"{settings.SERVER_HOST}/articles/{content.uuid}"
         else:
-            logger.error(f"Not supported item: {ac}")
+            logger.error(f"Not supported item: {content}")
 
 
         title = f"{user} 发表了{verb}"
@@ -57,6 +57,6 @@ def build_rss(activities: List, site)->str:
         fe.id(link)
         fe.description(description)
         fe.author(name=user)
-        fe.pubDate(ac.updated_at)
+        fe.pubDate(content.updated_at)
     result = fg.rss_str(pretty=True)
     return result

--- a/chafan_core/app/services/activity_policy.py
+++ b/chafan_core/app/services/activity_policy.py
@@ -1,0 +1,432 @@
+"""Per-verb policy for domain events: what gets written, and who receives it.
+
+Background
+----------
+Every user-visible thing that happens on Chafan is described by an
+:class:`~chafan_core.app.schemas.event.EventInternal` — an immutable fact such
+as "user 3 answered question 7 at T". That one event can end up in as many as
+four sinks:
+
+``Activity``
+    The publishable event log. One row carries the serialized event plus the
+    site it may be seen in.
+``Feed``
+    A delivery record: ``(activity_id, receiver_id)``. N rows per Activity, one
+    per recipient. Written by fan-out at publication time.
+``Notification``
+    A *directed* delivery to one receiver, with read/delivered state and a push
+    side effect. Re-serializes the event rather than referencing the Activity.
+``CoinPayment.event_json``
+    The event as the *reason* for a coin transfer.
+
+Until now, the rules governing those four sinks lived in four disconnected
+places: the (dead) ``feed_impl.get_activity_dist_info``, the followers-only
+``feed_impl.lookup_activity_receiver_list``, ``feed_impl``'s
+``ALWAYS_PUBLIC_EVENT_VERBS``, and 21 hand-written ``create_with_content``
+call sites spread over ``crud_message`` and six ``services`` modules. Nothing
+enforced that a verb was handled consistently, or handled at all.
+
+:data:`POLICY` is that knowledge in one place.
+
+What is authoritative here, and what is only recorded
+-----------------------------------------------------
+This module is deliberately split between fields that *drive* behavior and
+fields that merely *describe* it. Consolidation came first; moving the
+remaining call sites behind a single ``emit()`` seam is a separate change.
+
+Authoritative — the code reads these and behaves accordingly:
+
+* :attr:`EventPolicy.feed_audience` — consumed by
+  ``feed_impl.lookup_activity_receiver_list``.
+* :attr:`EventPolicy.always_public` — consumed by
+  ``feed_impl._is_public_activity``.
+
+Descriptive — an audit of what the scattered call sites do today. Nothing
+reads these at runtime; they exist so the next change has a map instead of a
+grep, and so drift is visible in review:
+
+* :attr:`EventPolicy.writes_activity`, :attr:`EventPolicy.notifies`,
+  :attr:`EventPolicy.pays_coins`, :attr:`EventPolicy.emitted_by`.
+
+Recorded but not applied:
+
+* :attr:`EventPolicy.unapplied_feed_audience` and
+  :attr:`EventPolicy.unapplied_exclusions` preserve the audience rules from
+  ``get_activity_dist_info``, the v1 fan-out that this change deletes. That
+  function was unreferenced, so those rules are **not** in force today: the
+  live fan-out delivers to the subject's followers and nobody else. They are
+  kept because they encode intent that was expensive to work out and would
+  otherwise be lost with the code.
+
+Every verb reachable through ``EventInternal`` must appear in :data:`POLICY`;
+``scripts/check.py`` fails the build otherwise.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from typing import Mapping, Optional, Tuple
+
+
+class Audience(enum.Enum):
+    """A group of users resolved from an event, relative to its subject."""
+
+    #: Everyone following the user who caused the event.
+    SUBJECT_FOLLOWERS = "subject_followers"
+    #: Members of the site the event happened in.
+    SITE_MEMBERS = "site_members"
+    #: The moderator of the site the event refers to.
+    SITE_MODERATOR = "site_moderator"
+    #: The instance superuser.
+    SUPERUSER = "superuser"
+    #: Author of the question the event refers to.
+    QUESTION_AUTHOR = "question_author"
+    #: Users subscribed to the question the event refers to.
+    QUESTION_SUBSCRIBERS = "question_subscribers"
+    #: Author of the answer the event refers to.
+    ANSWER_AUTHOR = "answer_author"
+    #: Users who bookmarked the answer the event refers to.
+    ANSWER_BOOKMARKERS = "answer_bookmarkers"
+    #: Author of the article the event refers to.
+    ARTICLE_AUTHOR = "article_author"
+    #: Subscribers of the article column the event refers to.
+    ARTICLE_COLUMN_SUBSCRIBERS = "article_column_subscribers"
+    #: Author of the submission the event refers to.
+    SUBMISSION_AUTHOR = "submission_author"
+    #: Author of the comment being replied to.
+    PARENT_COMMENT_AUTHOR = "parent_comment_author"
+    #: Users @-mentioned in the comment body.
+    MENTIONED_USERS = "mentioned_users"
+    #: Members of the message channel, excluding the sender.
+    CHANNEL_MEMBERS = "channel_members"
+    #: The user named by the event (invitee, followee, ...).
+    TARGET_USER = "target_user"
+    #: The user a reward was created for.
+    REWARD_RECEIVER = "reward_receiver"
+    #: The user who funded a reward.
+    REWARD_GIVER = "reward_giver"
+
+
+class Exclusion(enum.Enum):
+    """A group subtracted from a resolved audience."""
+
+    #: Never deliver an event back to whoever caused it.
+    SUBJECT = "subject"
+    #: Skip the author of the content acted upon.
+    CONTENT_AUTHOR = "content_author"
+    #: Skip users who already upvoted the same content.
+    EXISTING_UPVOTERS = "existing_upvoters"
+    #: Skip users already subscribed to the column.
+    EXISTING_SUBSCRIBERS = "existing_subscribers"
+    #: Skip users who already follow the user being followed.
+    EXISTING_FOLLOWERS_OF_TARGET = "existing_followers_of_target"
+    #: Skip the user named by the event.
+    TARGET_USER = "target_user"
+
+
+@dataclass(frozen=True)
+class EventPolicy:
+    """What the system does today with one verb, and what it was meant to do.
+
+    See the module docstring for which fields drive behavior and which are a
+    record of the current scattered implementation.
+    """
+
+    #: The ``verb`` discriminator of the event content model.
+    verb: str
+
+    # -- authoritative ----------------------------------------------------
+    #: Audience receiving a ``Feed`` row when this verb is fanned out. ``None``
+    #: means no fan-out happens for this verb today.
+    feed_audience: Optional[Audience] = None
+    #: Visible in the random/discovery feed regardless of site readability.
+    always_public: bool = False
+
+    # -- descriptive ------------------------------------------------------
+    #: Whether any code path writes an ``Activity`` row for this verb.
+    writes_activity: bool = False
+    #: Receivers of a ``Notification`` for this verb today.
+    notifies: Tuple[Audience, ...] = ()
+    #: Whether the event is used as a ``CoinPayment`` reason.
+    pays_coins: bool = False
+    #: Dotted references to the functions that construct this event. Empty
+    #: means the verb has no live emitter: it survives only so that rows
+    #: already in the database keep materializing.
+    emitted_by: Tuple[str, ...] = ()
+
+    # -- recorded, not applied --------------------------------------------
+    #: Audiences ``get_activity_dist_info`` (v1, deleted) also delivered to.
+    unapplied_feed_audience: Tuple[Audience, ...] = ()
+    #: Exclusions ``get_activity_dist_info`` (v1, deleted) applied.
+    unapplied_exclusions: Tuple[Exclusion, ...] = ()
+
+    #: Free-text note about anything irregular in the current handling.
+    note: str = ""
+
+
+_POLICIES: Tuple[EventPolicy, ...] = (
+    # -- content creation -------------------------------------------------
+    EventPolicy(
+        "create_question",
+        writes_activity=True,
+        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        emitted_by=("services.postprocess.postprocess_new_question",),
+        unapplied_feed_audience=(Audience.SITE_MEMBERS,),
+        unapplied_exclusions=(Exclusion.SUBJECT,),
+    ),
+    EventPolicy(
+        "answer_question",
+        writes_activity=True,
+        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        notifies=(Audience.QUESTION_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_answer",),
+        unapplied_feed_audience=(Audience.QUESTION_SUBSCRIBERS,),
+        unapplied_exclusions=(Exclusion.SUBJECT,),
+    ),
+    EventPolicy(
+        "create_article",
+        writes_activity=True,
+        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        always_public=True,
+        notifies=(Audience.ARTICLE_COLUMN_SUBSCRIBERS,),
+        emitted_by=(
+            "crud.crud_article.create_with_author",
+            "services.postprocess.postprocess_new_article",
+            "services.postprocess.postprocess_updated_article",
+        ),
+        unapplied_feed_audience=(Audience.ARTICLE_COLUMN_SUBSCRIBERS,),
+        unapplied_exclusions=(Exclusion.SUBJECT,),
+        note=(
+            "Three emitters, so publishing one article writes two or three "
+            "Activity rows; only postprocess_new_article fans out. "
+            "create_with_author writes unconditionally, including for drafts. "
+            "Column subscribers get a notification but no feed entry."
+        ),
+    ),
+    EventPolicy(
+        "create_submission",
+        writes_activity=True,
+        emitted_by=("crud.crud_submission.create_with_author",),
+        unapplied_exclusions=(Exclusion.SUBJECT,),
+        note="Activity is written but never fanned out (TODO in postprocess_new_submission).",
+    ),
+    # -- comments ---------------------------------------------------------
+    EventPolicy(
+        "comment_question",
+        writes_activity=True,
+        notifies=(Audience.QUESTION_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_comment",),
+        note="Activity only when the comment is shared to timeline; never fanned out.",
+    ),
+    EventPolicy(
+        "comment_answer",
+        writes_activity=True,
+        notifies=(Audience.ANSWER_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_comment",),
+        note="Activity only when the comment is shared to timeline; never fanned out.",
+    ),
+    EventPolicy(
+        "comment_article",
+        writes_activity=True,
+        always_public=True,
+        notifies=(Audience.ARTICLE_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_comment",),
+        note="Activity only when the comment is shared to timeline; never fanned out.",
+    ),
+    EventPolicy(
+        "comment_submission",
+        writes_activity=True,
+        notifies=(Audience.SUBMISSION_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_comment",),
+        note="Activity only when the comment is shared to timeline; never fanned out.",
+    ),
+    EventPolicy(
+        "reply_comment",
+        writes_activity=True,
+        notifies=(Audience.PARENT_COMMENT_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_comment",),
+        note="Activity only when the comment is shared to timeline; never fanned out.",
+    ),
+    EventPolicy(
+        "mentioned_in_comment",
+        notifies=(Audience.MENTIONED_USERS,),
+        emitted_by=("services.postprocess.notify_mentioned_users",),
+    ),
+    # -- votes ------------------------------------------------------------
+    EventPolicy(
+        "upvote_answer",
+        writes_activity=True,
+        notifies=(Audience.ANSWER_AUTHOR,),
+        pays_coins=True,
+        emitted_by=(
+            "crud.crud_answer.upvote",
+            "services.answers.upvote_answer",
+        ),
+        unapplied_exclusions=(
+            Exclusion.SUBJECT,
+            Exclusion.EXISTING_UPVOTERS,
+            Exclusion.CONTENT_AUTHOR,
+        ),
+    ),
+    EventPolicy(
+        "upvote_question",
+        writes_activity=True,
+        emitted_by=("crud.crud_question.upvote",),
+        unapplied_exclusions=(
+            Exclusion.SUBJECT,
+            Exclusion.EXISTING_UPVOTERS,
+            Exclusion.CONTENT_AUTHOR,
+        ),
+    ),
+    EventPolicy(
+        "upvote_article",
+        writes_activity=True,
+        always_public=True,
+        emitted_by=("crud.crud_article.upvote",),
+        unapplied_exclusions=(
+            Exclusion.SUBJECT,
+            Exclusion.EXISTING_UPVOTERS,
+            Exclusion.CONTENT_AUTHOR,
+        ),
+    ),
+    EventPolicy(
+        "upvote_submission",
+        writes_activity=True,
+        emitted_by=("crud.crud_submission.upvote",),
+        unapplied_exclusions=(Exclusion.SUBJECT,),
+    ),
+    # -- following / subscribing -----------------------------------------
+    EventPolicy(
+        "follow_user",
+        writes_activity=True,
+        notifies=(Audience.TARGET_USER,),
+        emitted_by=("crud.crud_user.add_follower", "services.me.follow_user"),
+        unapplied_exclusions=(
+            Exclusion.SUBJECT,
+            Exclusion.TARGET_USER,
+            Exclusion.EXISTING_FOLLOWERS_OF_TARGET,
+        ),
+    ),
+    EventPolicy(
+        "follow_article_column",
+        writes_activity=True,
+        always_public=True,
+        emitted_by=("crud.crud_user.subscribe_article_column",),
+        unapplied_exclusions=(
+            Exclusion.SUBJECT,
+            Exclusion.EXISTING_SUBSCRIBERS,
+            Exclusion.CONTENT_AUTHOR,
+        ),
+    ),
+    # -- edits and suggestions -------------------------------------------
+    EventPolicy(
+        "edit_question",
+        notifies=(Audience.QUESTION_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_updated_question",),
+    ),
+    EventPolicy(
+        "answer_update",
+        notifies=(Audience.ANSWER_BOOKMARKERS,),
+        emitted_by=("services.postprocess.postprocess_new_answer",),
+    ),
+    EventPolicy(
+        "create_submission_suggestion",
+        notifies=(Audience.SUBMISSION_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_submission_suggestion",),
+    ),
+    EventPolicy(
+        "accept_submission_suggestion",
+        emitted_by=("services.postprocess.postprocess_accept_submission_suggestion",),
+        note="Emitter builds the event but discards it; nothing is delivered.",
+    ),
+    EventPolicy(
+        "create_answer_suggest_edit",
+        notifies=(Audience.ANSWER_AUTHOR,),
+        emitted_by=("services.postprocess.postprocess_new_answer_suggest_edit",),
+    ),
+    EventPolicy(
+        "accept_answer_suggest_edit",
+        emitted_by=("services.postprocess.postprocess_accept_answer_suggest_edit",),
+        note="Emitter builds the event but discards it; nothing is delivered.",
+    ),
+    # -- sites, invitations, messages -------------------------------------
+    EventPolicy(
+        "create_site",
+        pays_coins=True,
+        emitted_by=("services.sites.create_site",),
+    ),
+    EventPolicy(
+        "create_site_need_approval",
+        notifies=(Audience.SUPERUSER,),
+        emitted_by=("services.sites.create_site",),
+    ),
+    EventPolicy(
+        "apply_join_site",
+        notifies=(Audience.SITE_MODERATOR,),
+        emitted_by=("services.sites.apply_join_site",),
+    ),
+    EventPolicy(
+        "invite_join_site",
+        notifies=(Audience.TARGET_USER,),
+        emitted_by=("services.users.invite_user_to_site",),
+    ),
+    EventPolicy(
+        "invite_answer",
+        notifies=(Audience.TARGET_USER,),
+        emitted_by=("services.questions.invite_answer",),
+    ),
+    EventPolicy(
+        "invite_new_user",
+        pays_coins=True,
+        emitted_by=("services.accounts.reward_inviter",),
+    ),
+    EventPolicy(
+        "create_message",
+        notifies=(Audience.CHANNEL_MEMBERS,),
+        emitted_by=("crud.crud_message.create_with_author",),
+    ),
+    # -- rewards ----------------------------------------------------------
+    EventPolicy(
+        "create_answer_question_reward",
+        notifies=(Audience.REWARD_RECEIVER,),
+        emitted_by=("services.rewards.create_reward",),
+    ),
+    EventPolicy(
+        "claim_answer_question_reward",
+        notifies=(Audience.REWARD_GIVER,),
+        emitted_by=("services.rewards.claim_reward",),
+    ),
+    # -- no live emitter --------------------------------------------------
+    # Retained so that rows already persisted with these verbs still
+    # materialize. Nothing in the codebase constructs them.
+    EventPolicy("site_broadcast", note="No live emitter."),
+    EventPolicy("system_broadcast", note="No live emitter."),
+    EventPolicy("system_send_invitation", note="No live emitter."),
+    EventPolicy("invited_user_activated", note="No live emitter."),
+)
+
+
+POLICY: Mapping[str, EventPolicy] = {p.verb: p for p in _POLICIES}
+
+assert len(POLICY) == len(_POLICIES), "duplicate verb in _POLICIES"
+
+
+#: Verbs shown in the random/discovery feed even when their site is not
+#: publicly readable. Derived from :data:`POLICY` so there is one source.
+ALWAYS_PUBLIC_EVENT_VERBS: frozenset[str] = frozenset(
+    p.verb for p in _POLICIES if p.always_public
+)
+
+
+def feed_audience_of(verb: str) -> Audience | None:
+    """Audience for ``verb``'s fan-out, or ``None`` if it is not fanned out.
+
+    Returns ``None`` for a verb absent from :data:`POLICY` as well;
+    ``scripts/check.py`` guarantees that cannot happen for a verb reachable
+    through ``EventInternal``.
+    """
+    policy = POLICY.get(verb)
+    if policy is None:
+        return None
+    return policy.feed_audience

--- a/chafan_core/app/services/feed_impl.py
+++ b/chafan_core/app/services/feed_impl.py
@@ -1,8 +1,5 @@
 from chafan_core.app.infra.request_context import RequestContext
-from typing import Dict, List, NamedTuple, Optional, Set, Any
-import sentry_sdk
-import json
-from sqlalchemy.orm import Session
+from typing import Dict, List, NamedTuple, Optional, Set
 
 from chafan_core.db.base_class import Base as BaseCrudModel
 from chafan_core.app import crud, models, schemas
@@ -10,24 +7,16 @@ from chafan_core.app.infra.request_context import RequestContext
 from chafan_core.app.schemas.activity import UserFeedSettings
 from chafan_core.app.schemas.event import (
     AnswerQuestionInternal,
-    CommentAnswerInternal,
-    CommentArticleInternal,
-    CommentQuestionInternal,
-    CommentSubmissionInternal,
     CreateArticleInternal,
     CreateQuestionInternal,
-    CreateSubmissionInternal,
     EventInternal,
-    FollowUserInternal,
-    ReplyCommentInternal,
-    SubscribeArticleColumnInternal,
-    UpvoteAnswerInternal,
-    UpvoteArticleInternal,
-    UpvoteQuestionInternal,
-    UpvoteSubmissionInternal,
 )
-from chafan_core.app.infra.runtime import execute_with_broker, execute_with_db
-from chafan_core.db.session import SessionLocal
+from chafan_core.app.services.activity_policy import (
+    ALWAYS_PUBLIC_EVENT_VERBS,
+    Audience,
+    feed_audience_of,
+)
+from chafan_core.app.infra.runtime import execute_with_broker
 from chafan_core.utils.base import map_, unwrap
 
 import logging
@@ -42,13 +31,29 @@ class ActivityDistributionInfo(NamedTuple):
 
 
 def lookup_activity_receiver_list(broker: RequestContext, activity: models.Activity)->ActivityDistributionInfo:
+    """Resolve who receives a Feed row for ``activity``.
+
+    The audience per verb comes from :data:`activity_policy.POLICY`; see that
+    module for the full matrix and for the v1 rules that are recorded there
+    but not yet applied.
+    """
     try:
         event = EventInternal.parse_raw(activity.event_json)
     except Exception:
         logger.error("failed to parse Event " + activity.event_json)
         return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
-    # TODO We need to consider different types of events 2025-07-20
     logger.info(f"get event: {event}")
+    audience = feed_audience_of(event.content.verb)
+    if audience is None:
+        # No verb reaching fan-out today has a null audience; if one does, the
+        # policy table is the place to add it.
+        logger.warning(
+            "no feed audience for verb %s; activity %s not fanned out",
+            event.content.verb,
+            activity.id,
+        )
+        return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
+    assert audience is Audience.SUBJECT_FOLLOWERS, audience
     assert hasattr(event.content, "subject_id")
     read_db = broker.get_db()
     subject = crud.user.get(read_db, id=event.content.subject_id)
@@ -81,115 +86,6 @@ def new_activity_into_feed(broker: RequestContext, activity:models.Activity) -> 
                 )
             )
 
-
-
-# TODO This is the v1 api. To be removed. 2025-07-19
-def get_activity_dist_info(
-    read_db: Session, activity: models.Activity
-) -> ActivityDistributionInfo:
-    receivers: Dict[int, models.User] = {}
-    subject_user_uuid = None
-    try:
-        event = EventInternal.parse_raw(activity.event_json)
-    except Exception:
-        sentry_sdk.capture_message(
-            f"Failed to materialize event: {activity.event_json}",
-        )
-        return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
-
-    if hasattr(event.content, "subject_id"):
-        subject = crud.user.get(read_db, id=event.content.subject_id)
-        assert subject is not None
-        subject_user_uuid = subject.uuid
-        for follower in subject.followers:
-            receivers[follower.id] = follower
-    if isinstance(event.content, CreateQuestionInternal):
-        question = crud.question.get(read_db, id=event.content.question_id)
-        assert question is not None
-        for profile in question.site.profiles:
-            if profile.owner_id != event.content.subject_id:
-                receivers[profile.owner_id] = profile.owner
-    elif isinstance(event.content, CreateSubmissionInternal):
-        pass
-    elif isinstance(event.content, UpvoteSubmissionInternal):
-        pass
-    elif isinstance(event.content, CommentSubmissionInternal):
-        pass
-    elif isinstance(event.content, CreateArticleInternal):
-        article = crud.article.get(read_db, id=event.content.article_id)
-        assert article is not None
-        for user in article.article_column.subscribers:
-            if user.id != event.content.subject_id:
-                receivers[user.id] = user
-    elif isinstance(event.content, AnswerQuestionInternal):
-        answer = crud.answer.get(read_db, id=event.content.answer_id)
-        assert answer is not None
-        for user in answer.question.subscribers:
-            if user.id != event.content.subject_id:
-                receivers[user.id] = user
-    elif isinstance(event.content, UpvoteAnswerInternal):
-        answer = crud.answer.get(read_db, id=event.content.answer_id)
-        assert answer is not None
-        for answer_upvote in read_db.query(models.Answer_Upvotes).filter_by(
-            answer_id=answer.id
-        ):
-            if answer_upvote.voter_id in receivers:
-                del receivers[answer_upvote.voter_id]
-        if answer.author_id in receivers:
-            del receivers[answer.author_id]
-    elif isinstance(event.content, UpvoteQuestionInternal):
-        question = crud.question.get(read_db, id=event.content.question_id)
-        assert question is not None
-        for question_upvote in read_db.query(models.QuestionUpvotes).filter_by(
-            question_id=question.id
-        ):
-            if question_upvote.voter_id in receivers:
-                del receivers[question_upvote.voter_id]
-        if question.author_id in receivers:
-            del receivers[question.author_id]
-    elif isinstance(event.content, UpvoteArticleInternal):
-        article = crud.article.get(read_db, id=event.content.article_id)
-        assert article is not None
-        for article_upvote in read_db.query(models.ArticleUpvotes).filter_by(
-            article_id=article.id
-        ):
-            if article_upvote.voter_id in receivers:
-                del receivers[article_upvote.voter_id]
-        if article.author_id in receivers:
-            del receivers[article.author_id]
-    elif isinstance(event.content, SubscribeArticleColumnInternal):
-        article_column = crud.article_column.get(
-            read_db, id=event.content.article_column_id
-        )
-        assert article_column is not None
-        for user in article_column.subscribers:
-            if user.id in receivers:
-                del receivers[user.id]
-        if article_column.owner_id in receivers:
-            del receivers[article_column.owner_id]
-    elif isinstance(event.content, CommentQuestionInternal):
-        pass
-    elif isinstance(event.content, CommentAnswerInternal):
-        pass
-    elif isinstance(event.content, CommentArticleInternal):
-        pass
-    elif isinstance(event.content, ReplyCommentInternal):
-        pass
-    elif isinstance(event.content, FollowUserInternal):
-        if event.content.user_id in receivers:
-            del receivers[event.content.user_id]
-        removed_receiver_ids = []
-        for receiver in receivers.values():
-            if receiver.followed.filter_by(id=event.content.user_id).first():  # type: ignore
-                removed_receiver_ids.append(receiver.id)
-        for i in removed_receiver_ids:
-            del receivers[i]
-    else:
-        sentry_sdk.capture_message(f"Unknown event: {event}")
-        return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
-    return ActivityDistributionInfo(
-        receiver_ids=set(receivers.keys()), subject_user_uuid=subject_user_uuid
-    )
 
 
 def is_blocked(
@@ -273,22 +169,23 @@ def get_site_activities(
     site,
     limit: int,
     all_sites = False) -> List[BaseCrudModel]:
+    """The content (questions/answers/articles) behind a site's recent activities."""
     db = ctx.get_db()
     if (site is None) and (not all_sites):
         raise ValueError("site not found ")
     if (not all_sites) and (not site.public_readable):
         raise ValueError("site not allowed ")
-    feeds = db.query(models.Activity)
+    activities = db.query(models.Activity)
     if not all_sites:
-        feeds = feeds.filter_by(site_id=site.id)
-    feeds = feeds.order_by(models.Activity.id.desc()).limit(limit)
-    activities = []
-    for feed in feeds:
-        obj = get_content_from_eventjson(ctx, feed.event_json)
+        activities = activities.filter_by(site_id=site.id)
+    activities = activities.order_by(models.Activity.id.desc()).limit(limit)
+    contents = []
+    for activity in activities:
+        obj = get_content_from_eventjson(ctx, activity.event_json)
         if obj is not None:
             assert isinstance(obj, BaseCrudModel)
-            activities.append(obj)
-    return activities
+            contents.append(obj)
+    return contents
 
 def get_activities_v2(
     *,
@@ -366,11 +263,6 @@ def get_activities( # TODO to remove this function
         return data
     else:
         return []
-
-
-ALWAYS_PUBLIC_EVENT_VERBS = set(
-    ["create_article", "comment_article", "upvote_article", "follow_article_column"]
-)
 
 
 def _is_public_activity(activity: schemas.Activity) -> bool:

--- a/chafan_core/app/services/postprocess.py
+++ b/chafan_core/app/services/postprocess.py
@@ -22,8 +22,6 @@ from chafan_core.app.recs.indexing import (
     compute_interesting_users_ids_for_visitor_user,
 )
 from chafan_core.app.schemas.event import (
-    AcceptAnswerSuggestEditInternal,
-    AcceptSubmissionSuggestionInternal,
     AnswerQuestionInternal,
     AnswerUpdateInternal,
     CommentAnswerInternal,
@@ -33,7 +31,6 @@ from chafan_core.app.schemas.event import (
     CreateAnswerSuggestEditInternal,
     CreateArticleInternal,
     CreateQuestionInternal,
-    CreateSubmissionInternal,
     CreateSubmissionSuggestionInternal,
     EditQuestionInternal,
     EventInternal,
@@ -308,16 +305,9 @@ def postprocess_new_submission(submission_id: int) -> None:
     def runnable(broker: RequestContext) -> None:
         submission = crud.submission.get(broker.get_db(), id=submission_id)
         assert submission is not None
-        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
-        event_json = EventInternal(
-            created_at=utc_now,
-            content=CreateSubmissionInternal(
-                subject_id=submission.author.id,
-                submission_id=submission.id,
-            ),
-        ).json()
-        # TODO event to feed? 2025-Sep-14
-
+        # NOTE: crud.submission.create_with_author already wrote the Activity for
+        # this submission, but nothing fans it out. See activity_policy.POLICY
+        # ["create_submission"]. TODO event to feed? 2025-Sep-14
         rep.award_submission_created(broker.get_db(), submission.author, submission)
         postprocess_submission_common(submission)
         for webhook in submission.site.webhooks:
@@ -363,14 +353,8 @@ def postprocess_accept_submission_suggestion(submission_suggestion_id: int) -> N
             db, id=submission_suggestion_id
         )
         assert submission_suggestion is not None
-        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
-        event_json = EventInternal(
-            created_at=utc_now,
-            content=AcceptSubmissionSuggestionInternal(
-                subject_id=submission_suggestion.author.id,
-                submission_suggestion_id=submission_suggestion.id,
-            ),
-        ).json()
+        # NOTE: no accept_submission_suggestion event is delivered anywhere.
+        # See activity_policy.POLICY["accept_submission_suggestion"].
         rep.award_submission_suggestion_accepted(
             db, submission_suggestion.author, submission_suggestion
         )
@@ -410,14 +394,8 @@ def postprocess_accept_answer_suggest_edit(answer_suggest_edit_id: int) -> None:
             db, id=answer_suggest_edit_id
         )
         assert answer_suggest_edit is not None
-        utc_now = get_utc_now()
-        event_json = EventInternal(
-            created_at=utc_now,
-            content=AcceptAnswerSuggestEditInternal(
-                subject_id=answer_suggest_edit.author.id,
-                answer_suggest_edit_id=answer_suggest_edit.id,
-            ),
-        ).json()
+        # NOTE: no accept_answer_suggest_edit event is delivered anywhere.
+        # See activity_policy.POLICY["accept_answer_suggest_edit"].
         rep.award_answer_suggest_accepted(
             db, answer_suggest_edit.author, answer_suggest_edit
         )

--- a/chafan_core/app/services/rss.py
+++ b/chafan_core/app/services/rss.py
@@ -14,15 +14,15 @@ def site_rss_xml(ctx, *, subdomain: str) -> str:
         raise HTTPException_(status_code=404, detail="No such site " + subdomain)
     if not site.public_readable:
         raise HTTPException_(status_code=405, detail="Not allowed " + subdomain)
-    activities = get_site_activities(ctx, site, settings.LIMIT_RSS_RESPONSE_ITEMS)
-    return build_rss(activities, site)
+    contents = get_site_activities(ctx, site, settings.LIMIT_RSS_RESPONSE_ITEMS)
+    return build_rss(contents, site)
 
 
 def full_site_rss_xml(ctx, *, passcode: str) -> str:
     code = settings.DEBUG_ADMIN_TOOL_FULL_SITE_PASSCODE
     if code is None or code == "" or code != passcode:
         raise HTTPException_(status_code=405, detail="Not allowed ")
-    activities = get_site_activities(
+    contents = get_site_activities(
         ctx, None, settings.LIMIT_RSS_ADMIN_TOOL_FULL_SITE_ITEMS, True
     )
-    return build_rss(activities, site=None)
+    return build_rss(contents, site=None)

--- a/chafan_core/tests/app/test_activity_policy.py
+++ b/chafan_core/tests/app/test_activity_policy.py
@@ -1,0 +1,69 @@
+"""Pins that the policy table reproduces the behavior it consolidated.
+
+These are equivalence tests, not specification tests. They encode what the
+scattered constants and branches did *before* the table existed, so that this
+consolidation can be reviewed as behavior-neutral. When a later change
+deliberately alters a rule, the expectation here is meant to change with it.
+"""
+
+from chafan_core.app.services.activity_policy import (
+    ALWAYS_PUBLIC_EVENT_VERBS,
+    POLICY,
+    Audience,
+    feed_audience_of,
+)
+
+# Verbatim from feed_impl.ALWAYS_PUBLIC_EVENT_VERBS before consolidation.
+_LEGACY_ALWAYS_PUBLIC = {
+    "create_article",
+    "comment_article",
+    "upvote_article",
+    "follow_article_column",
+}
+
+# The only verbs whose Activity reaches new_activity_into_feed today, i.e. the
+# three postprocess paths that call it. Everything else writes an Activity (or
+# not) but is never fanned out.
+_LEGACY_FANNED_OUT = {"create_question", "answer_question", "create_article"}
+
+
+def test_always_public_verbs_unchanged() -> None:
+    assert set(ALWAYS_PUBLIC_EVENT_VERBS) == _LEGACY_ALWAYS_PUBLIC
+
+
+def test_fanned_out_verbs_resolve_to_subject_followers() -> None:
+    """The pre-consolidation fan-out delivered to the subject's followers."""
+    for verb in _LEGACY_FANNED_OUT:
+        assert feed_audience_of(verb) is Audience.SUBJECT_FOLLOWERS, verb
+
+
+def test_other_verbs_have_no_feed_audience() -> None:
+    """No verb gains a fan-out it did not have before."""
+    for verb, policy in POLICY.items():
+        if verb in _LEGACY_FANNED_OUT:
+            continue
+        assert policy.feed_audience is None, verb
+
+
+def test_unknown_verb_has_no_feed_audience() -> None:
+    assert feed_audience_of("no_such_verb") is None
+
+
+def test_every_policy_is_keyed_by_its_own_verb() -> None:
+    for verb, policy in POLICY.items():
+        assert policy.verb == verb
+
+
+def test_verbs_without_emitter_deliver_nothing() -> None:
+    """A verb with no live emitter must not claim any sink.
+
+    These exist only so rows already persisted keep materializing; if one ever
+    grows an emitter, its policy has to be filled in at the same time.
+    """
+    for verb, policy in POLICY.items():
+        if policy.emitted_by:
+            continue
+        assert not policy.writes_activity, verb
+        assert policy.feed_audience is None, verb
+        assert policy.notifies == (), verb
+        assert not policy.pays_coins, verb

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,36 @@
+# Glossary
+
+**Last reviewed:** 2026-08-02
+
+## event, activity, feed, notification
+
+Four names for closely related things. Mixing them up is the usual source of
+confusion in this area.
+
+| Term | Stored as | How many | Answers |
+|---|---|---|---|
+| **Event** | JSON in an `event_json` column | one per occurrence | *what happened* |
+| **Activity** | `activity` table | one per published event | *what happened, and where it may be seen* |
+| **Feed** | `feed` table | N per Activity — one per recipient | *who should see it* |
+| **Notification** | `notification` table | one per targeted recipient | *who must be told* |
+
+The short version: **Activity is subject-oriented and carries the payload;
+Feed is receiver-oriented and is just an index**, `(activity_id, receiver_id)`.
+Notification is a directed delivery with read state, and re-serializes the
+event rather than pointing at an Activity.
+
+An event can also land in a fourth place: `CoinPayment.event_json`, where it is
+the *reason* for a coin transfer rather than something anyone reads.
+
+`EventInternal` vs `Event`: `EventInternal` holds ids and is what gets
+persisted. `Event` is the materialized, permission-checked shape returned by
+the API. `responders/event.materialize_event` converts one to the other.
+
+Which of those sinks each verb actually reaches is recorded per verb in
+[`chafan_core/app/services/activity_policy.py`](../chafan_core/app/services/activity_policy.py).
+
+Two things the model does *not* currently live up to, so the names don't
+mislead: an `Activity` row is not written for every event (and `create_article`
+writes two or three), and `Feed` carries a `subject_user_uuid` denormalization
+so profile timelines can be read from it — a subject query answered from the
+receiver table.

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -3,20 +3,37 @@ from dotenv import load_dotenv  # isort:skip
 load_dotenv()  # isort:skip
 
 from chafan_core.app.common import EVENT_TEMPLATES
-from chafan_core.app.schemas.event import Event
+from chafan_core.app.schemas.event import Event, EventInternal
+from chafan_core.app.services.activity_policy import POLICY
 
-_event_verbs = []
 
-for k, v in Event.model_json_schema()["$defs"].items():
-    if k == "ContentVisibility":
-        continue
-    if "properties" not in v:
-        raise Exception(f"{k}: {v}")
-    if "verb" in v["properties"]:
-        _event_verbs.append(v["properties"]["verb"]["default"])
+def _verbs_of(model) -> set:
+    verbs = set()
+    for k, v in model.model_json_schema()["$defs"].items():
+        if k == "ContentVisibility":
+            continue
+        if "properties" not in v:
+            raise Exception(f"{k}: {v}")
+        if "verb" in v["properties"]:
+            verbs.add(v["properties"]["verb"]["default"])
+    return verbs
 
-assert set(EVENT_TEMPLATES.keys()) == set(_event_verbs), set(
+
+_event_verbs = _verbs_of(Event)
+
+assert set(EVENT_TEMPLATES.keys()) == _event_verbs, set(
     EVENT_TEMPLATES.keys()
-).symmetric_difference(set(_event_verbs))
+).symmetric_difference(_event_verbs)
 
-print(f"Checked _event_verbs: {_event_verbs}")
+print(f"Checked _event_verbs: {sorted(_event_verbs)}")
+
+# Every verb that can be written must have a row in the policy table, so that
+# adding an event forces a decision about its sinks instead of defaulting to
+# "goes nowhere" silently.
+_internal_verbs = _verbs_of(EventInternal)
+
+assert set(POLICY.keys()) == _internal_verbs, set(POLICY.keys()).symmetric_difference(
+    _internal_verbs
+)
+
+print(f"Checked activity_policy verbs: {len(POLICY)}")


### PR DESCRIPTION
Step 1 and 2 of the activity/feed plan: consolidate the per-verb policy, plus the low-blast-radius renames. **No behavior change.** Step 3 (the centralized `emit()` seam) is deliberately not here.

## The problem

The rules governing what happens when a domain event occurs lived in four disconnected places:

| Where | What it held |
|---|---|
| `feed_impl.get_activity_dist_info` | The richest audience rules — and **dead**, unreferenced since the v2 rewrite |
| `feed_impl.lookup_activity_receiver_list` | The live rule: subject's followers, for every verb |
| `feed_impl.ALWAYS_PUBLIC_EVENT_VERBS` | A four-element literal set |
| 21 `create_with_content` call sites | Notification audiences, across `crud_message` and six `services` modules |

Nothing enforced that a verb was handled consistently, or handled at all.

## What this adds

`services/activity_policy.py` records, for each of the **35 verbs reachable through `EventInternal`**, which sinks it reaches. There are four sinks, not two — the fourth is `CoinPayment.event_json`, which carries `create_site`, `invite_new_user`, and `upvote_answer` as the *reason* for a coin transfer.

The module is explicitly split:

- **Authoritative** (read at runtime): `feed_audience` → `lookup_activity_receiver_list`; `always_public` → `_is_public_activity`.
- **Descriptive** (an audit, nothing reads it): `writes_activity`, `notifies`, `pays_coins`, `emitted_by`.
- **Recorded but not applied**: `unapplied_feed_audience` / `unapplied_exclusions` preserve the rules from `get_activity_dist_info`, which this PR deletes. That function was unreferenced, so those rules are **not** in force today — the live fan-out reaches the subject's followers and nobody else. They're kept because they encode intent that was expensive to reconstruct and would be lost with the code.

`emitted_by` uses dotted callable references rather than line numbers, so it doesn't rot on the next edit.

## Evidence it's behavior-neutral

- **OpenAPI document is byte-identical** to `main` (generated both sides, `diff` clean).
- **Full unit suite**: 431 passed, 9 skipped.
- **mypy**: 977 → 956 errors, entirely from deleting the 109-line dead function. No new errors.
- **Both architecture ratchets pass** (`check_layer_imports`, `check_service_commits`).
- `tests/app/test_activity_policy.py` pins the equivalence directly: the derived `ALWAYS_PUBLIC_EVENT_VERBS` equals the old literal set; the three fanned-out verbs still resolve to `SUBJECT_FOLLOWERS`; **no other verb gains a fan-out**.

`scripts/check.py` now fails the build if a verb is missing from the table — following the precedent of the existing `EVENT_TEMPLATES` coverage assertion. Adding an event forces a decision about its sinks instead of defaulting to "goes nowhere" silently.

## Findings surfaced by building the table

Recorded in the `note` fields rather than fixed here:

- **Four verbs have no live emitter at all** — `site_broadcast`, `system_broadcast`, `system_send_invitation`, `invited_user_activated`. Nothing constructs them. They're retained so rows already in the database keep materializing.
- **Two verbs build an event and discard it**: `accept_submission_suggestion` and `accept_answer_suggest_edit` assigned `event_json` to an unused local. Nothing was ever delivered. Removed, with a note pointing at the policy entry.
- **`create_article` has three emitters** — `crud_article.create_with_author`, `postprocess_new_article`, `postprocess_updated_article` — so publishing one article writes two or three `Activity` rows, and only the middle one fans out. `create_with_author` also writes unconditionally, including for drafts.
- **Column subscribers get a notification but no feed entry**, because the v1 rule that delivered to them died with `get_activity_dist_info`.

## Corrections to my earlier analysis

Two entries in the matrix I sketched before writing this were wrong, both found by reading the emit sites directly: `upvote_answer` **does** notify the answer author (`services/answers.py:448`), and `follow_user` **does** notify the followed user (`services/me.py:261`). The table is the checked version.

## Renames included (Tier 1 only)

Local names that actively lied. No model names, no schema names, no table names — those wait until step 3 settles what the right names are.

- `get_site_activities` built `feeds` from `models.Activity` and returned content models in a list named `activities`. Both now say what they hold, as does `build_rss`'s parameter.
- Dropped a stray `print(ac.__dict__)` in `responders/rss.py` that dumped a full ORM object to stdout on every RSS render.

I tried typing `build_rss(contents: List[Union[Answer, Question, Article]])` and backed it out — it surfaced 7 new mypy errors from the usual SQLAlchemy `Column[str]` vs `str` friction. The docstring carries the same information at no cost.

## Deliberately left for step 3

`get_activities` (self-marked `TODO to remove`) and `CACHE_REWIND_SIZE` are both dead, but they're *readers*, and the read path is the feed restructure's business. This PR draws the line at *policy*. Same reasoning for the `feed_settings = None` TODOs in `get_activities_v2`.

Also unaddressed and tracked separately: the RSS visibility bug, where `retrieve_content` bypasses the responder permission layer and exposes `visibility=REGISTERED` answer bodies to anonymous readers. That's a security fix on its own branch, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeMsA6xCmFfkz3epPkyaEZ
