### PR TITLE
activity: contain delivery failures in events.distribute (3b-1)

### DIFF
--- a/chafan_core/app/crud/crud_user.py
+++ b/chafan_core/app/crud/crud_user.py
@@ -167,6 +167,15 @@ def get_superuser(db: Session) -> User:
     return user
 
 
+def try_get_superuser(db: Session) -> Optional[User]:
+    """Like :func:`get_superuser`, but ``None`` instead of an assertion.
+
+    For callers that must not take down their transaction over a missing
+    superuser -- see ``services.events._superuser``.
+    """
+    return db.query(User).filter_by(is_superuser=True).first()
+
+
 def try_get_visitor_user(db: Session) -> Optional[User]:
     if not settings.VISITOR_USER_ID:
         return None

--- a/chafan_core/app/services/events.py
+++ b/chafan_core/app/services/events.py
@@ -30,6 +30,11 @@ the domain write, does not decide *whether* an event occurred (conditions like
 Delivery is not visibility. A ``Feed`` row grants nothing -- ``materialize_*``
 runs the full responder permission check per receiver at read time. A wrong
 audience yields an item that silently does not render, not a leak.
+
+Failure is contained. Because it writes into the caller's transaction, a
+delivery problem here -- an audience that cannot be resolved, a Redis push that
+fails -- is logged and skipped rather than raised, so it cannot roll back the
+domain writes the caller already made. See :func:`_resolve`.
 """
 
 from __future__ import annotations
@@ -236,7 +241,11 @@ def _site_moderator(ctx: RequestContext, c: object) -> Set[int]:
 
 
 def _superuser(ctx: RequestContext, c: object) -> Set[int]:
-    return {crud.user.get_superuser(ctx.get_db()).id}
+    superuser = crud.user.try_get_superuser(ctx.get_db())
+    if superuser is None:
+        logger.warning("no superuser; delivering to nobody")
+        return set()
+    return {superuser.id}
 
 
 def _reward_receiver(ctx: RequestContext, c: object) -> Set[int]:
@@ -278,11 +287,32 @@ _RESOLVERS: Dict[Audience, Callable[[RequestContext, object], Set[int]]] = {
 
 
 def _resolve(ctx: RequestContext, audience: Audience, content: object) -> Set[int]:
+    """Resolve an audience to receiver ids, degrading to nobody on failure.
+
+    A resolver walks relationships that the event's ids only *probably* reach:
+    a deleted column, a site with no moderator, a superuser row that is missing
+    in this deployment. None of that should propagate, because ``distribute``
+    writes into the caller's transaction -- an audience that cannot be resolved
+    would otherwise roll back the domain-adjacent writes the caller already
+    made, such as the reputation award and webhook delivery that precede
+    ``distribute`` in ``postprocess_new_article``.
+
+    Losing a fan-out is recoverable and visible in the log; losing the caller's
+    transaction is neither.
+    """
     resolver = _RESOLVERS.get(audience)
     if resolver is None:
         logger.warning("no resolver for audience %s; delivering to nobody", audience)
         return set()
-    return resolver(ctx, content)
+    try:
+        return resolver(ctx, content)
+    except Exception:
+        logger.exception(
+            "could not resolve audience %s for %s; delivering to nobody",
+            audience,
+            getattr(content, "verb", content),
+        )
+        return set()
 
 
 def _apply_exclusions(
@@ -382,7 +412,17 @@ def notify_users(
                 event_json=event.json(),
             ),
         )
-        push_notification(ctx, notif=notification)
+        # Same reasoning as _resolve: the row is durable in the caller's
+        # transaction and the receiver will see it on their next load. A Redis
+        # blip must not undo that, nor the caller's other writes.
+        try:
+            push_notification(ctx, notif=notification)
+        except Exception:
+            logger.exception(
+                "could not push notification %s to user %s; row still written",
+                notification.id,
+                receiver_id,
+            )
 
 
 # --------------------------------------------------------------------------

--- a/chafan_core/tests/app/test_events_distribute.py
+++ b/chafan_core/tests/app/test_events_distribute.py
@@ -7,6 +7,7 @@ point of deriving from the event is that the ids resolve.
 """
 
 import datetime
+from typing import Set
 
 import pytest
 from sqlalchemy.orm import Session
@@ -18,6 +19,7 @@ from chafan_core.app.schemas.event import (
     AnswerQuestionInternal,
     CommentQuestionInternal,
     CreateQuestionInternal,
+    CreateSiteNeedApprovalInternal,
     EventInternal,
     FollowUserInternal,
     UpvoteQuestionInternal,
@@ -283,6 +285,114 @@ def test_comment_activity_requires_shared_to_timeline(ctx) -> None:
     )
     assert activity is not None
     assert activity.site_id == site.id
+
+
+def _boom(ctx: RequestContext, content: object) -> Set[int]:
+    raise RuntimeError("audience gone")
+
+
+def test_unresolvable_feed_audience_does_not_lose_the_activity(
+    ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken resolver costs the fan-out, not the event or the caller's writes."""
+    db = ctx.get_db()
+    author = _user(db)
+    follower = _user(db)
+    author.followers.append(follower)
+    site = _site(db, moderator=author)
+    question = _question(db, author_id=author.id, site=site)
+    db.flush()
+    # Stands in for the domain-adjacent write that precedes distribute in
+    # postprocess_new_article -- the reputation award that used to be rolled
+    # back when an audience blew up.
+    prior_id = question.id
+
+    monkeypatch.setitem(events._RESOLVERS, Audience.SUBJECT_FOLLOWERS, _boom)
+
+    activity = events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=CreateQuestionInternal(
+                subject_id=author.id, question_id=question.id
+            ),
+        ),
+    )
+
+    assert activity is not None, "the event still happened; it must still be recorded"
+    assert db.query(models.Feed).filter_by(activity_id=activity.id).count() == 0
+    assert crud.question.get(db, id=prior_id) is not None
+
+
+def test_unresolvable_notify_audience_does_not_raise(
+    ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = ctx.get_db()
+    answerer = _user(db)
+    db.flush()
+    before = db.query(models.Notification).count()
+
+    monkeypatch.setitem(events._RESOLVERS, Audience.QUESTION_AUTHOR, _boom)
+
+    activity = events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=AnswerQuestionInternal(subject_id=answerer.id, answer_id=0),
+        ),
+    )
+
+    assert activity is not None
+    assert db.query(models.Notification).count() == before
+
+
+def test_missing_superuser_delivers_to_nobody(
+    ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The concrete assert this change removes: crud.user.get_superuser."""
+    db = ctx.get_db()
+    subject = _user(db)
+    db.flush()
+    before = db.query(models.Notification).count()
+
+    monkeypatch.setattr(crud.user, "try_get_superuser", lambda db: None)
+
+    events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=CreateSiteNeedApprovalInternal(subject_id=subject.id, channel_id=1),
+        ),
+    )
+
+    assert db.query(models.Notification).count() == before
+
+
+def test_failed_push_still_writes_the_notification(
+    ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Redis blip loses the realtime ping, not the row behind it."""
+    db = ctx.get_db()
+    follower = _user(db)
+    followed = _user(db)
+    db.flush()
+    before = db.query(models.Notification).count()
+
+    def _push_boom(ctx: RequestContext, *, notif: models.Notification) -> None:
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(events, "push_notification", _push_boom)
+
+    events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=FollowUserInternal(subject_id=follower.id, user_id=followed.id),
+        ),
+        sinks=frozenset({events.Sink.NOTIFICATION}),
+    )
+
+    assert db.query(models.Notification).count() == before + 1
 
 
 def test_unknown_verb_is_dropped_not_raised(ctx) -> None:

--- a/docs/proposals/2026-08-03-event-distribution.md
+++ b/docs/proposals/2026-08-03-event-distribution.md
@@ -1,9 +1,11 @@
 # Event distribution: one seam for Activity, Feed and Notification
 
-**Status:** agreed; 3a partially implemented on `refactor/event-distribute` (incomplete, uncommitted) | **Date:** 2026-08-03 | **Last reviewed:** 2026-08-03
+**Status:** 3a landed; 3b-1 done, 3b-2 next | **Date:** 2026-08-03 | **Last reviewed:** 2026-08-04
 
 Step 3 of the activity/feed work. Step 1 (the per-verb policy table) and step 2
-(Tier 1 renames) landed in #166 as `ca23ef7`.
+(Tier 1 renames) landed in #166 as `ca23ef7`. Step 3a landed in #167 as
+`773e8b0`; the sections below are kept in the tense they were written in, and
+"Implementation notes" records where the implementation departed from them.
 
 Terminology is defined in [`docs/glossary.md`](../glossary.md). The per-verb
 matrix lives in
@@ -151,19 +153,61 @@ belongs with the outbox question in step 4.
 
 ## Scope: 3a and 3b
 
-**3a — behavior-neutral.** Introduce `distribute()`, move the nine emissions up,
-route all ~27 sites through it. Proven the same way #166 was: byte-identical
-OpenAPI, full unit suite, plus tests pinning that every verb still reaches the
+**3a — behavior-neutral. Landed in #167 (`773e8b0`).** Introduce `distribute()`,
+move the nine emissions up, route all 27 sites through it. Proven the same way
+#166 was: byte-identical OpenAPI, full unit suite (426 passed, 9 skipped), both
+ratchets clean, mypy unchanged at 956 errors, plus
+`tests/app/test_events_distribute.py` pinning that every verb still reaches the
 same sinks. Large diff, no behavior change.
 
-**3b — the fixes 3a makes obvious.** The `create_article` triple-emit; drafts
-writing activities; column subscribers getting a notification but no feed row;
-`distribute()` degrading instead of asserting when an audience cannot be
-resolved (today that rollback also discards the reputation award and webhook
-delivery). Small diff, real behavior change, reviewed on its own merits.
+**3b — the fixes 3a makes obvious.** Small diff, real behavior change, reviewed
+on its own merits. Split again on the same principle, so the safety net lands
+before the change that needs it:
 
-Keeping them apart matters because the neutrality argument is otherwise
+- **3b-1, containment.** `distribute()` degrades instead of raising when an
+  audience cannot be resolved. No audience changes, so nobody's feed or inbox
+  moves. Landed first because every later change is safer behind it.
+- **3b-2, the article fixes.** The duplicate `create_article` emit, drafts
+  writing activities, and column subscribers getting a notification but no feed
+  row. These are one story — publishing an article distributes it exactly once,
+  to everyone it should reach.
+
+**No data migration.** Owner's call, 2026-08-04: tolerate what is already in the
+table and fix only new events. Duplicate rows are cosmetic and articles that
+already published silently stay that way. The one place stale rows could still
+bite is `feed_impl.retrieve_content`, which is fixed in code rather than data —
+see below.
+
+Keeping 3a and 3b apart matters because the neutrality argument is otherwise
 unavailable exactly where the diff is largest.
+
+### Corrections to the 3b list
+
+Both found by reading the code before starting, 2026-08-04.
+
+**It is a double-emit, not a triple.** Every article lifecycle produces exactly
+two `Activity` rows, never three. `postprocess_new_article` runs only when the
+article is created published; `postprocess_updated_article` emits only when
+`not was_published`; `is_published` is never reverted. The two are therefore
+mutually exclusive per article, and the count is always `articles.create_article`
+plus exactly one of them. `activity_policy`'s note still says "two or three".
+
+**The draft path is worse than "drafts write activities".** An article created
+as a draft and published later gets *no distribution at all*: the Activity is
+written at draft time, and the publish transition is `sinks={ACTIVITY}` — no
+fan-out, no column-subscriber notification. The junk row is the smaller half of
+this bug.
+
+**`retrieve_content` has no `is_published` check** (`feed_impl.py`), unlike the
+answer branch beside it. Not reachable anonymously today: article activities
+carry `site_id=None` and the public RSS path filters by site, leaving only the
+passcode-gated `all_sites` tool. Latent, and cheap to close while 3b-2 is
+already in this file's blast radius.
+
+**Widening the feed audience needs a type change.** `EventPolicy.feed_audience`
+is a single `Optional[Audience]`. Reaching followers *and* column subscribers
+makes it a tuple, which touches every policy row, `distribute`, and the check
+script — the only part of 3b with real surface area.
 
 ## Implementation notes
 
@@ -207,21 +251,27 @@ already compute `upvoted_before` before calling crud, so the relocation is
 clean. `Comment.shared_to_timeline` is persisted, so the Activity precondition
 for comments is derived rather than passed.
 
-**`crud_notification.create_with_content` can be deleted outright.** Once
-`notify_mentioned_users` uses `events.notify_users`, it has no callers, and the
-standing `FIXME crud layer should not call higher level components` goes with
+**`crud_notification.create_with_content` was deleted outright.** Once
+`notify_mentioned_users` used `events.notify_users` it had no callers, and the
+standing `FIXME crud layer should not call higher level components` went with
 it.
+
+**`crud_activity.py` went too — all of it.** Not anticipated by the plan:
+`distribute` builds the `Activity` itself, which left all nine factories dead,
+and the module's only other callers were three readers used exclusively by
+`tests/app/crud/a/test_crud_activity.py`. Module and test file both deleted
+(202 + 330 lines).
 
 **`postprocess_updated_article` needs converting** from `execute_with_db` to
 `execute_with_broker`, since `distribute` takes a `RequestContext`.
 
-## Also fold in
+## Also folded in (done in #167)
 
-`activity_policy.POLICY` still lists `emitted_by` for
-`accept_submission_suggestion` and `accept_answer_suggest_edit`, but #166
-removed the dead event construction from both. Should become `emitted_by=()`
-with a "no live emitter" note, moving them in with the other four. Descriptive
-only; no behavior depends on it.
+`activity_policy.POLICY` still listed `emitted_by` for
+`accept_submission_suggestion` and `accept_answer_suggest_edit` after #166
+removed the dead event construction from both. Both are now `emitted_by=()`
+with a "no live emitter" note, alongside the other four. Descriptive only; no
+behavior depended on it.
 
 ## Deferred to step 4
 


### PR DESCRIPTION
Step 3b-1 of the activity/feed work, the first slice of [3b](../blob/main/docs/proposals/2026-08-03-event-distribution.md). 3a landed in #167.

## The problem

`distribute` writes into the caller's transaction. That is what keeps timing a property of the caller — but it also means a *delivery* problem takes the caller's *domain* writes down with it. `postprocess_new_article` awards reputation and queues webhook delivery **before** calling `distribute`, so an audience that cannot be resolved discards both.

Two ways that happens today:

- `crud.user.get_superuser` asserts, and `Audience.SUPERUSER` reaches it on `create_site_need_approval`.
- `push_notification` talks to Redis, so a blip there rolls back the `Notification` row it was trying to announce — the receiver loses the notification entirely, not just the realtime ping.

## The change

Both are now logged and skipped:

- **`_resolve` degrades an unresolvable audience to nobody.** Resolvers walk relationships the event's ids only *probably* reach — a deleted column, a site with no moderator, a superuser row missing in this deployment.
- **`notify_users` keeps the row when the push fails.** The receiver sees it on their next load.

The `Activity` is still written either way. The event happened, so it is still recorded; what degrades is the fan-out, and it degrades visibly in the log. Losing a fan-out is recoverable. Losing the caller's transaction is not.

`crud.user.try_get_superuser` is added alongside `get_superuser`, mirroring the existing `try_get_visitor_user`, so `events` does not depend on catching an `AssertionError`.

## Scope note

The Redis-push containment is one item wider than 3b's written list, which named audience resolution only. It is the same defect class with a much likelier trigger, and containing half of it leaves the bug reachable — but it is a separable commit if you would rather it went on its own.

## Verification

No audience changes, so nobody's feed or inbox moves.

- OpenAPI byte-identical to `main`
- 430 passed / 9 skipped (426 + 4 new). Each new test was checked to fail without the fix.
- `check_layer_imports` and `check_service_commits` clean; `scripts/check.py` clean
- mypy flat at 956

## Also

Records in the proposal two corrections found while reading 3b's list before starting:

- **`create_article` is a double-emit, not a triple.** `postprocess_new_article` runs only when the article is created published, `postprocess_updated_article` only when `not was_published`, and `is_published` is never reverted — so the two are mutually exclusive per article.
- **The draft path's real damage** is not the junk row: an article created as a draft and published later gets *no distribution at all*, because the publish transition is `sinks={ACTIVITY}`.

Both are for 3b-2 to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)