### PR TITLE
activity: publish an article once, to everyone (3b-2)

### DIFF
--- a/chafan_core/app/services/activity_policy.py
+++ b/chafan_core/app/services/activity_policy.py
@@ -21,7 +21,7 @@ four sinks:
 
 Until now, the rules governing those four sinks lived in four disconnected
 places: the (dead) ``feed_impl.get_activity_dist_info``, the followers-only
-``feed_impl.lookup_activity_receiver_list``, ``feed_impl``'s
+``feed_impl.lookup_activity_receiver_list`` (both since deleted), ``feed_impl``'s
 ``ALWAYS_PUBLIC_EVENT_VERBS``, and 21 hand-written ``create_with_content``
 call sites spread over ``crud_message`` and six ``services`` modules. Nothing
 enforced that a verb was handled consistently, or handled at all.
@@ -35,8 +35,7 @@ fields that merely *describe* it.
 
 Authoritative — the code reads these and behaves accordingly:
 
-* :attr:`EventPolicy.feed_audience` — ``events.distribute`` and
-  ``feed_impl.lookup_activity_receiver_list``.
+* :attr:`EventPolicy.feed_audience` — ``events.distribute``.
 * :attr:`EventPolicy.always_public` — ``feed_impl._is_public_activity``.
 * :attr:`EventPolicy.writes_activity`, :attr:`EventPolicy.notifies` and
   :attr:`EventPolicy.notify_exclusions` — ``events.distribute``.
@@ -136,9 +135,9 @@ class EventPolicy:
     verb: str
 
     # -- authoritative ----------------------------------------------------
-    #: Audience receiving a ``Feed`` row when this verb is fanned out. ``None``
-    #: means no fan-out happens for this verb today.
-    feed_audience: Optional[Audience] = None
+    #: Audiences receiving a ``Feed`` row when this verb is fanned out, unioned.
+    #: Empty means no fan-out happens for this verb today.
+    feed_audience: Tuple[Audience, ...] = ()
     #: Visible in the random/discovery feed regardless of site readability.
     always_public: bool = False
 
@@ -173,7 +172,7 @@ _POLICIES: Tuple[EventPolicy, ...] = (
     EventPolicy(
         "create_question",
         writes_activity=True,
-        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        feed_audience=(Audience.SUBJECT_FOLLOWERS,),
         emitted_by=("services.postprocess.postprocess_new_question",),
         unapplied_feed_audience=(Audience.SITE_MEMBERS,),
         unapplied_exclusions=(Exclusion.SUBJECT,),
@@ -181,7 +180,7 @@ _POLICIES: Tuple[EventPolicy, ...] = (
     EventPolicy(
         "answer_question",
         writes_activity=True,
-        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        feed_audience=(Audience.SUBJECT_FOLLOWERS,),
         notifies=(Audience.QUESTION_AUTHOR,),
         notify_exclusions=(Exclusion.SUBJECT,),
         emitted_by=("services.postprocess.postprocess_new_answer",),
@@ -191,21 +190,23 @@ _POLICIES: Tuple[EventPolicy, ...] = (
     EventPolicy(
         "create_article",
         writes_activity=True,
-        feed_audience=Audience.SUBJECT_FOLLOWERS,
+        feed_audience=(
+            Audience.SUBJECT_FOLLOWERS,
+            Audience.ARTICLE_COLUMN_SUBSCRIBERS,
+        ),
         always_public=True,
         notifies=(Audience.ARTICLE_COLUMN_SUBSCRIBERS,),
         emitted_by=(
-            "crud.crud_article.create_with_author",
             "services.postprocess.postprocess_new_article",
             "services.postprocess.postprocess_updated_article",
         ),
-        unapplied_feed_audience=(Audience.ARTICLE_COLUMN_SUBSCRIBERS,),
         unapplied_exclusions=(Exclusion.SUBJECT,),
         note=(
-            "Three emitters, so publishing one article writes two or three "
-            "Activity rows; only postprocess_new_article fans out. "
-            "create_with_author writes unconditionally, including for drafts. "
-            "Column subscribers get a notification but no feed entry."
+            "Two emitters, one per publication route: created-published goes "
+            "through postprocess_new_article, draft-then-published through "
+            "postprocess_updated_article. They are mutually exclusive per "
+            "article because is_published is never reverted, so a published "
+            "article has exactly one Activity and a draft has none."
         ),
     ),
     EventPolicy(
@@ -426,16 +427,3 @@ assert len(POLICY) == len(_POLICIES), "duplicate verb in _POLICIES"
 ALWAYS_PUBLIC_EVENT_VERBS: frozenset[str] = frozenset(
     p.verb for p in _POLICIES if p.always_public
 )
-
-
-def feed_audience_of(verb: str) -> Audience | None:
-    """Audience for ``verb``'s fan-out, or ``None`` if it is not fanned out.
-
-    Returns ``None`` for a verb absent from :data:`POLICY` as well;
-    ``scripts/check.py`` guarantees that cannot happen for a verb reachable
-    through ``EventInternal``.
-    """
-    policy = POLICY.get(verb)
-    if policy is None:
-        return None
-    return policy.feed_audience

--- a/chafan_core/app/services/articles.py
+++ b/chafan_core/app/services/articles.py
@@ -24,7 +24,6 @@ from chafan_core.app.user_permission import (
 from chafan_core.utils.base import ContentVisibility, HTTPException_
 from chafan_core.utils.constants import MAX_ARCHIVE_PAGINATION_LIMIT
 import chafan_core.app.responders as responders
-from chafan_core.app.schemas.event import CreateArticleInternal
 from chafan_core.app.services import events
 
 logger = logging.getLogger(__name__)
@@ -234,20 +233,9 @@ def create_article(
     new_article = crud.article.create_with_author(
         ctx.get_db(), obj_in=article_in, author_id=current_user.id
     )
-    # Activity only, and unconditionally -- including for drafts. Both are
-    # what crud.article.create_with_author did before this moved up; neither
-    # is right, and 3b removes this emitter entirely.
-    events.distribute(
-        ctx,
-        EventInternal(
-            created_at=new_article.created_at,
-            content=CreateArticleInternal(
-                subject_id=new_article.author_id,
-                article_id=new_article.id,
-            ),
-        ),
-        sinks=frozenset({events.Sink.ACTIVITY}),
-    )
+    # No event here. Creating an article is not publishing one: a draft must
+    # not reach the timeline, and a published article is announced exactly once
+    # by postprocess_new_article. This emitter used to fire for both.
     data = article_schema(ctx, new_article)
     assert data is not None
     return new_article, data

--- a/chafan_core/app/services/events.py
+++ b/chafan_core/app/services/events.py
@@ -465,14 +465,18 @@ def distribute(
         db.flush()
 
     if Sink.FEED in sinks and activity is not None and policy.feed_audience:
-        receivers = _resolve(ctx, policy.feed_audience, content)
-        deliver(ctx, activity, receivers)
+        feed_receivers: Set[int] = set()
+        for audience in policy.feed_audience:
+            feed_receivers |= _resolve(ctx, audience, content)
+        deliver(ctx, activity, feed_receivers)
 
     if Sink.NOTIFICATION in sinks and policy.notifies:
-        receivers: Set[int] = set()
+        notify_receivers: Set[int] = set()
         for audience in policy.notifies:
-            receivers |= _resolve(ctx, audience, content)
-        receivers = _apply_exclusions(receivers, policy.notify_exclusions, content)
-        notify_users(ctx, event, receivers)
+            notify_receivers |= _resolve(ctx, audience, content)
+        notify_receivers = _apply_exclusions(
+            notify_receivers, policy.notify_exclusions, content
+        )
+        notify_users(ctx, event, notify_receivers)
 
     return activity

--- a/chafan_core/app/services/feed_impl.py
+++ b/chafan_core/app/services/feed_impl.py
@@ -1,5 +1,5 @@
 from chafan_core.app.infra.request_context import RequestContext
-from typing import Dict, List, NamedTuple, Optional, Set
+from typing import List, Optional
 
 from chafan_core.db.base_class import Base as BaseCrudModel
 from chafan_core.app import crud, models, schemas
@@ -11,81 +11,12 @@ from chafan_core.app.schemas.event import (
     CreateQuestionInternal,
     EventInternal,
 )
-from chafan_core.app.services.activity_policy import (
-    ALWAYS_PUBLIC_EVENT_VERBS,
-    Audience,
-    feed_audience_of,
-)
+from chafan_core.app.services.activity_policy import ALWAYS_PUBLIC_EVENT_VERBS
 from chafan_core.app.infra.runtime import execute_with_broker
 from chafan_core.utils.base import map_, unwrap
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-class ActivityDistributionInfo(NamedTuple):
-    receiver_ids: Set[int]
-    subject_user_uuid: Optional[str]
-
-
-
-
-def lookup_activity_receiver_list(broker: RequestContext, activity: models.Activity)->ActivityDistributionInfo:
-    """Resolve who receives a Feed row for ``activity``.
-
-    The audience per verb comes from :data:`activity_policy.POLICY`; see that
-    module for the full matrix and for the v1 rules that are recorded there
-    but not yet applied.
-    """
-    try:
-        event = EventInternal.parse_raw(activity.event_json)
-    except Exception:
-        logger.error("failed to parse Event " + activity.event_json)
-        return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
-    logger.info(f"get event: {event}")
-    audience = feed_audience_of(event.content.verb)
-    if audience is None:
-        # No verb reaching fan-out today has a null audience; if one does, the
-        # policy table is the place to add it.
-        logger.warning(
-            "no feed audience for verb %s; activity %s not fanned out",
-            event.content.verb,
-            activity.id,
-        )
-        return ActivityDistributionInfo(receiver_ids=set(), subject_user_uuid=None)
-    assert audience is Audience.SUBJECT_FOLLOWERS, audience
-    assert hasattr(event.content, "subject_id")
-    read_db = broker.get_db()
-    subject = crud.user.get(read_db, id=event.content.subject_id)
-    assert subject is not None
-    subject_user_uuid = subject.uuid
-    receivers: Dict[int, models.User] = {}
-    for follower in subject.followers:
-        receivers[follower.id] = follower
-    # TODO didn't consider blocker setting 2025-07-19
-    return ActivityDistributionInfo(
-        receiver_ids=set(receivers.keys()), subject_user_uuid=subject_user_uuid
-    )
-
-def new_activity_into_feed(broker: RequestContext, activity:models.Activity) -> None:
-    logger.info("generating feed for activity "  + str(activity.id))
-    assert activity.id is not None
-    assert isinstance(activity.id, int)
-    receivers = lookup_activity_receiver_list(broker, activity)
-    write_db = broker.get_db()
-    for receiver_id in receivers.receiver_ids:
-        feed = write_db.query(models.Feed)  \
-            .filter_by(receiver_id=receiver_id, activity_id=activity.id) \
-            .first()
-        if feed is None:
-            write_db.add(
-                models.Feed(
-                    receiver_id=receiver_id,
-                    activity_id=activity.id,
-                    subject_user_uuid=receivers.subject_user_uuid,
-                )
-            )
-
 
 
 def is_blocked(
@@ -152,7 +83,17 @@ def retrieve_content(event: EventInternal, ctx) -> Optional[BaseCrudModel]:
             return None
         return answer
     if isinstance(c, CreateArticleInternal):
-        return articles_service.get_article_by_id(db, c.article_id)
+        article = articles_service.get_article_by_id(db, c.article_id)
+        if article is None:
+            return None
+        if article.is_deleted or (not article.is_published):
+            # This branch used to have no check at all, unlike the two above.
+            # Activity rows written for drafts before that emitter was removed
+            # are still in the table, and this is what keeps them from
+            # dereferencing here.
+            logger.warning("Skip a hidden article: " + str(article))
+            return None
+        return article
 
     logger.error(f"Not supported event type: {event}")
     return None #TODO throw exception

--- a/chafan_core/app/services/postprocess.py
+++ b/chafan_core/app/services/postprocess.py
@@ -390,7 +390,6 @@ def postprocess_new_article(article_id: int) -> None:
         )
         rep.award_article_created(broker.get_db(), article.author, article)
         events.distribute(broker, event_internal)
-        # TODO FIXME TABLE activitity 里同一篇文章有两条记录。看起来无害就先不管了 2025-aug-04
 
     execute_with_broker(runnable)
 
@@ -401,11 +400,10 @@ def postprocess_updated_article(article_id: int, was_published: bool) -> None:
         assert article is not None and article.is_published
         utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         if not was_published:
-            # NOTE: Since is_published will not be reverted, thus this should only be delivered once
-            # TODO: Implement the update subscription logic
-            # Activity only: this path has never fanned out or notified, and
-            # widening it here would not be a neutral change. 3b deletes this
-            # emitter outright -- it is one of create_article's three.
+            # The draft-to-published transition *is* the publication, so it
+            # distributes exactly like postprocess_new_article. is_published is
+            # never reverted, so this fires at most once per article -- and an
+            # article that took this route never fires the other one.
             events.distribute(
                 broker,
                 EventInternal(
@@ -415,7 +413,6 @@ def postprocess_updated_article(article_id: int, was_published: bool) -> None:
                         article_id=article.id,
                     ),
                 ),
-                sinks=frozenset({events.Sink.ACTIVITY}),
             )
 
     execute_with_broker(runnable)

--- a/chafan_core/tests/app/api/api_v1/test_articles.py
+++ b/chafan_core/tests/app/api/api_v1/test_articles.py
@@ -2,9 +2,11 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from chafan_core.app import crud
+from chafan_core.app import crud, models
 from chafan_core.app.config import settings
+from chafan_core.app.schemas.event import EventInternal
 from chafan_core.tests.conftest import ensure_user_has_coins
+from chafan_core.tests.utils.utils import random_short_lower_string
 from chafan_core.utils.base import get_uuid
 
 
@@ -686,3 +688,153 @@ def test_delete_article_nonexistent(
     )
     assert r.status_code == 400
     assert "doesn't exist" in r.json()["detail"]
+
+
+# =============================================================================
+# Distribution Tests (3b-2)
+# =============================================================================
+
+
+def _create_article(
+    client: TestClient,
+    headers: dict,
+    column_uuid: str,
+    *,
+    is_published: bool,
+) -> str:
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/",
+        headers=headers,
+        json={
+            "title": f"Distribution Article ({random_short_lower_string()})",
+            "content": {"source": "Body.", "editor": "tiptap"},
+            "article_column_uuid": column_uuid,
+            "is_published": is_published,
+            "writing_session_uuid": get_uuid(),
+            "visibility": "anyone",
+        },
+    )
+    r.raise_for_status()
+    return r.json()["uuid"]
+
+
+def _create_article_activities(db: Session, article_id: object) -> list:
+    """Activity rows announcing this specific article."""
+    found = []
+    for activity in db.query(models.Activity).all():
+        try:
+            content = EventInternal.parse_raw(str(activity.event_json)).content
+        except Exception:
+            continue
+        if (
+            getattr(content, "verb", None) == "create_article"
+            and getattr(content, "article_id", None) == article_id
+        ):
+            found.append(activity)
+    return found
+
+
+def test_published_article_announced_exactly_once(
+    client: TestClient,
+    db: Session,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    example_article_column_uuid: str,
+) -> None:
+    """Creating a published article used to write two Activity rows, not one.
+
+    create_article emitted one and postprocess_new_article emitted another.
+    """
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+
+    uuid = _create_article(
+        client, normal_user_token_headers, example_article_column_uuid,
+        is_published=True,
+    )
+
+    db.expire_all()
+    article = crud.article.get_by_uuid(db, uuid=uuid)
+    assert article is not None
+    assert len(_create_article_activities(db, article.id)) == 1
+
+
+def test_draft_is_not_announced_until_published(
+    client: TestClient,
+    db: Session,
+    normal_user_token_headers: dict,
+    normal_user_id: int,
+    moderator_user_token_headers: dict,
+    moderator_user_id: int,
+    normal_user_uuid: str,
+    example_article_column_uuid: str,
+) -> None:
+    """The draft path: no Activity while unpublished, full distribution after.
+
+    Publishing from a draft used to reach nobody -- the Activity was written at
+    draft time and the publish transition delivered to no feed and notified no
+    column subscriber.
+    """
+    ensure_user_has_coins(db, normal_user_id, coins=100)
+
+    # A follower (SUBJECT_FOLLOWERS) and a column subscriber
+    # (ARTICLE_COLUMN_SUBSCRIBERS). Same user here; both audiences must resolve.
+    r = client.post(
+        f"{settings.API_V1_STR}/me/follows/{normal_user_uuid}",
+        headers=moderator_user_token_headers,
+    )
+    assert r.status_code == 200, r.json()
+    r = client.post(
+        f"{settings.API_V1_STR}/me/article-column-subscriptions/{example_article_column_uuid}",
+        headers=moderator_user_token_headers,
+    )
+    assert r.status_code == 200, r.json()
+
+    uuid = _create_article(
+        client, normal_user_token_headers, example_article_column_uuid,
+        is_published=False,
+    )
+
+    db.expire_all()
+    article = crud.article.get_by_uuid(db, uuid=uuid)
+    assert article is not None
+    assert article.is_published is False
+    assert _create_article_activities(db, article.id) == [], (
+        "a draft must not reach the timeline"
+    )
+
+    notifications_before = (
+        db.query(models.Notification).filter_by(receiver_id=moderator_user_id).count()
+    )
+
+    r = client.put(
+        f"{settings.API_V1_STR}/articles/{uuid}",
+        headers=normal_user_token_headers,
+        json={
+            "updated_title": "Now Published",
+            "updated_content": {"source": "Body.", "editor": "tiptap"},
+            "is_draft": False,
+            "visibility": "anyone",
+        },
+    )
+    assert r.status_code == 200, r.json()
+
+    db.expire_all()
+    activities = _create_article_activities(db, article.id)
+    assert len(activities) == 1, "publishing announces the article exactly once"
+
+    feeds = (
+        db.query(models.Feed)
+        .filter(
+            models.Feed.receiver_id == moderator_user_id,
+            models.Feed.activity_id == activities[0].id,
+        )
+        .all()
+    )
+    assert feeds, "the published article did not fan out"
+
+    notifications_after = (
+        db.query(models.Notification).filter_by(receiver_id=moderator_user_id).count()
+    )
+    assert notifications_after > notifications_before, (
+        "column subscribers were not notified"
+    )

--- a/chafan_core/tests/app/api/api_v1/test_questions.py
+++ b/chafan_core/tests/app/api/api_v1/test_questions.py
@@ -673,9 +673,9 @@ def test_new_question_writes_activity_and_feed(
     """postprocess_new_question must persist both the Activity and its feed fanout.
 
     These run under execute_with_broker, which has no request boundary; the
-    Activity used to be committed mid-function before new_activity_into_feed
-    ran. Removing that commit means the flush alone has to assign activity.id,
-    and the single boundary at the end has to cover both writes.
+    Activity used to be committed mid-function before the fan-out ran. Removing
+    that commit means the flush alone has to assign activity.id, and the single
+    boundary at the end has to cover both writes.
     """
     ensure_user_in_site(
         client, db, normal_user_id, normal_user_uuid,

--- a/chafan_core/tests/app/test_activity_policy.py
+++ b/chafan_core/tests/app/test_activity_policy.py
@@ -10,7 +10,6 @@ from chafan_core.app.services.activity_policy import (
     ALWAYS_PUBLIC_EVENT_VERBS,
     POLICY,
     Audience,
-    feed_audience_of,
 )
 
 # Verbatim from feed_impl.ALWAYS_PUBLIC_EVENT_VERBS before consolidation.
@@ -21,32 +20,36 @@ _LEGACY_ALWAYS_PUBLIC = {
     "follow_article_column",
 }
 
-# The only verbs whose Activity reaches new_activity_into_feed today, i.e. the
-# three postprocess paths that call it. Everything else writes an Activity (or
-# not) but is never fanned out.
-_LEGACY_FANNED_OUT = {"create_question", "answer_question", "create_article"}
+# The only verbs that are fanned out. Everything else writes an Activity (or
+# not) but never reaches a Feed row.
+_FANNED_OUT = {"create_question", "answer_question", "create_article"}
 
 
 def test_always_public_verbs_unchanged() -> None:
     assert set(ALWAYS_PUBLIC_EVENT_VERBS) == _LEGACY_ALWAYS_PUBLIC
 
 
-def test_fanned_out_verbs_resolve_to_subject_followers() -> None:
-    """The pre-consolidation fan-out delivered to the subject's followers."""
-    for verb in _LEGACY_FANNED_OUT:
-        assert feed_audience_of(verb) is Audience.SUBJECT_FOLLOWERS, verb
+def test_fanned_out_verbs_reach_subject_followers() -> None:
+    """Every fanned-out verb still reaches the audience v1 delivered to."""
+    for verb in _FANNED_OUT:
+        assert Audience.SUBJECT_FOLLOWERS in POLICY[verb].feed_audience, verb
+
+
+def test_create_article_also_reaches_column_subscribers() -> None:
+    """3b-2: subscribers used to get a notification with no feed row to match."""
+    assert POLICY["create_article"].feed_audience == (
+        Audience.SUBJECT_FOLLOWERS,
+        Audience.ARTICLE_COLUMN_SUBSCRIBERS,
+    )
+    assert Audience.ARTICLE_COLUMN_SUBSCRIBERS in POLICY["create_article"].notifies
 
 
 def test_other_verbs_have_no_feed_audience() -> None:
     """No verb gains a fan-out it did not have before."""
     for verb, policy in POLICY.items():
-        if verb in _LEGACY_FANNED_OUT:
+        if verb in _FANNED_OUT:
             continue
-        assert policy.feed_audience is None, verb
-
-
-def test_unknown_verb_has_no_feed_audience() -> None:
-    assert feed_audience_of("no_such_verb") is None
+        assert policy.feed_audience == (), verb
 
 
 def test_every_policy_is_keyed_by_its_own_verb() -> None:
@@ -64,6 +67,6 @@ def test_verbs_without_emitter_deliver_nothing() -> None:
         if policy.emitted_by:
             continue
         assert not policy.writes_activity, verb
-        assert policy.feed_audience is None, verb
+        assert policy.feed_audience == (), verb
         assert policy.notifies == (), verb
         assert not policy.pays_coins, verb

--- a/docs/proposals/2026-08-03-event-distribution.md
+++ b/docs/proposals/2026-08-03-event-distribution.md
@@ -1,6 +1,6 @@
 # Event distribution: one seam for Activity, Feed and Notification
 
-**Status:** 3a landed; 3b-1 done, 3b-2 next | **Date:** 2026-08-03 | **Last reviewed:** 2026-08-04
+**Status:** 3a and 3b landed; step 4 open | **Date:** 2026-08-03 | **Last reviewed:** 2026-08-04
 
 Step 3 of the activity/feed work. Step 1 (the per-verb policy table) and step 2
 (Tier 1 renames) landed in #166 as `ca23ef7`. Step 3a landed in #167 as
@@ -164,13 +164,21 @@ same sinks. Large diff, no behavior change.
 on its own merits. Split again on the same principle, so the safety net lands
 before the change that needs it:
 
-- **3b-1, containment.** `distribute()` degrades instead of raising when an
-  audience cannot be resolved. No audience changes, so nobody's feed or inbox
-  moves. Landed first because every later change is safer behind it.
+- **3b-1, containment. Landed in #168 (`d090b16`).** `distribute()` degrades
+  instead of raising when an audience cannot be resolved, and a failed Redis
+  push no longer discards the `Notification` row it was announcing. No audience
+  changes, so nobody's feed or inbox moved. Landed first because every later
+  change is safer behind it.
 - **3b-2, the article fixes.** The duplicate `create_article` emit, drafts
   writing activities, and column subscribers getting a notification but no feed
-  row. These are one story — publishing an article distributes it exactly once,
-  to everyone it should reach.
+  row. One story: publishing an article distributes it exactly once, to
+  everyone it should reach.
+
+After 3b-2 the rule is: **`create_article` is emitted at publication, never at
+creation.** Both routes to publication emit it — `postprocess_new_article` for
+created-published, `postprocess_updated_article` for draft-then-published — and
+they are mutually exclusive per article, so a published article has exactly one
+`Activity` and a draft has none.
 
 **No data migration.** Owner's call, 2026-08-04: tolerate what is already in the
 table and fix only new events. Duplicate rows are cosmetic and articles that
@@ -185,29 +193,36 @@ unavailable exactly where the diff is largest.
 
 Both found by reading the code before starting, 2026-08-04.
 
-**It is a double-emit, not a triple.** Every article lifecycle produces exactly
+**It is a double-emit, not a triple.** Every article lifecycle produced exactly
 two `Activity` rows, never three. `postprocess_new_article` runs only when the
 article is created published; `postprocess_updated_article` emits only when
 `not was_published`; `is_published` is never reverted. The two are therefore
-mutually exclusive per article, and the count is always `articles.create_article`
-plus exactly one of them. `activity_policy`'s note still says "two or three".
+mutually exclusive per article, and the count was always
+`articles.create_article` plus exactly one of them.
 
-**The draft path is worse than "drafts write activities".** An article created
-as a draft and published later gets *no distribution at all*: the Activity is
-written at draft time, and the publish transition is `sinks={ACTIVITY}` — no
-fan-out, no column-subscriber notification. The junk row is the smaller half of
+**The draft path was worse than "drafts write activities".** An article created
+as a draft and published later got *no distribution at all*: the Activity was
+written at draft time, and the publish transition was `sinks={ACTIVITY}` — no
+fan-out, no column-subscriber notification. The junk row was the smaller half of
 this bug.
 
-**`retrieve_content` has no `is_published` check** (`feed_impl.py`), unlike the
-answer branch beside it. Not reachable anonymously today: article activities
-carry `site_id=None` and the public RSS path filters by site, leaving only the
-passcode-gated `all_sites` tool. Latent, and cheap to close while 3b-2 is
-already in this file's blast radius.
+**`retrieve_content` had no `is_published` check**, unlike the answer branch
+beside it. Not reachable anonymously: article activities carry `site_id=None`
+and the public RSS path filters by site, leaving only the passcode-gated
+`all_sites` tool. Latent rather than live, but it is also what makes "no
+migration" safe — it is the gate the draft-time rows already in the table now
+fail.
 
-**Widening the feed audience needs a type change.** `EventPolicy.feed_audience`
-is a single `Optional[Audience]`. Reaching followers *and* column subscribers
-makes it a tuple, which touches every policy row, `distribute`, and the check
-script — the only part of 3b with real surface area.
+**Widening the feed audience needed a type change.** `EventPolicy.feed_audience`
+was a single `Optional[Audience]`; reaching followers *and* column subscribers
+makes it a tuple, touching every policy row and `distribute`.
+
+**The second fan-out implementation was already dead.**
+`feed_impl.new_activity_into_feed` and `lookup_activity_receiver_list` lost
+their last caller when 3a introduced `events.deliver`, and
+`lookup_activity_receiver_list` asserted `audience is SUBJECT_FOLLOWERS` — the
+one thing standing in the way of a multi-audience fan-out. Deleted, along with
+`activity_policy.feed_audience_of`, whose only remaining callers were tests.
 
 ## Implementation notes
 
@@ -219,16 +234,16 @@ assumed one verb reaches one set of sinks. It does not: the same verb reaches
 *different* sinks from different callers, so `distribute` takes a keyword-only
 `sinks` to narrow the destinations.
 
-| Site | Why |
-|---|---|
-| `postprocess_comment_update` | Sharing an existing comment to the timeline writes an Activity but must not re-notify the author, who was notified at creation. |
-| `postprocess_updated_article` | Has never fanned out or notified; widening it would not be neutral. |
-| `articles.create_article` | Same — the crud-level write had neither. |
-| `me.follow_user` | Notification is unconditional, Activity only on a *new* follow. Two calls. |
+| Site | Why | Status |
+|---|---|---|
+| `postprocess_comment_update` | Sharing an existing comment to the timeline writes an Activity but must not re-notify the author, who was notified at creation. | in force |
+| `me.follow_user` | Notification is unconditional, Activity only on a *new* follow. Two calls. | in force |
+| `postprocess_updated_article` | Had never fanned out or notified; widening it would not have been neutral. | removed by 3b-2 |
+| `articles.create_article` | Same — the crud-level write had neither. | removed by 3b-2 (emitter deleted) |
 
-Three of the four are `create_article`/comment duplication, i.e. the escape
-hatch is mostly compensating for the bugs 3b removes. Worth re-checking after
-3b whether it can be deleted.
+Half the uses were compensating for the article bugs, exactly as suspected, and
+went with them. The two that remain are real: a verb genuinely reaching
+different sinks from different callers. The escape hatch stays.
 
 **`follow_user` does not collapse to a single call**, contrary to the plan
 above. `upvote_answer` does — both its sinks share the `not upvoted_before`
@@ -264,6 +279,14 @@ and the module's only other callers were three readers used exclusively by
 
 **`postprocess_updated_article` needs converting** from `execute_with_db` to
 `execute_with_broker`, since `distribute` takes a `RequestContext`.
+
+**Reputation is still asymmetric between the two publication routes.** Found
+while doing 3b-2 and deliberately left alone: `postprocess_new_article` calls
+`rep.award_article_created`, `postprocess_updated_article` does not, so an
+article published from a draft earns its author nothing. It is the same shape
+of bug 3b-2 fixes for distribution, but reputation is not one of
+`distribute`'s sinks, so fixing it here would have meant widening the change
+past the sink boundary the whole design rests on. Worth its own small change.
 
 ## Also folded in (done in #167)
 


### PR DESCRIPTION
The second and final slice of 3b. 3a landed in #167, 3b-1 in #168.

## The bug

Publishing an article wrote two `Activity` rows and reached the wrong people. Both follow from one mistake: `create_article` was emitted at **creation** rather than at publication.

| Route | Emitters |
|---|---|
| created published | `articles.create_article` + `postprocess_new_article` |
| draft, published later | `articles.create_article` (at draft time) + `postprocess_updated_article` |

The two postprocess emitters are mutually exclusive per article, since `is_published` is never reverted — so the count was always two, never the "two or three" the policy table claimed.

The draft route was the worse of the two. The Activity was written while the article was still a draft, and the publish transition ran with `sinks={ACTIVITY}` — so **an article published from a draft fanned out to nobody and notified no column subscriber.** It published silently.

## The fix

`create_article` is now emitted at publication and nowhere else. The emitter in `articles.create_article` is gone, and `postprocess_updated_article` distributes exactly like `postprocess_new_article`. A published article has exactly one Activity; a draft has none.

Column subscribers also got a notification but never a feed row, because the two deliveries were decided in different places. `feed_audience` becomes a tuple and `create_article` resolves to followers ∪ column subscribers — what the v1 rule recorded in `unapplied_feed_audience` always intended.

That widening was blocked by **a second fan-out implementation nobody was calling**: `feed_impl.new_activity_into_feed` and `lookup_activity_receiver_list` lost their last caller when 3a introduced `events.deliver`, and the latter asserted `audience is SUBJECT_FOLLOWERS`. Both deleted, along with `activity_policy.feed_audience_of`, whose only remaining callers were tests.

`feed_impl.retrieve_content` gains the `is_published` check the answer branch beside it already had. This is what makes "no migration" safe — draft-time Activity rows already in the table now fail the gate on read instead of dereferencing a draft.

## Verification

- 432 passed / 9 skipped. Two new tests, both checked to fail without the fix.
- OpenAPI byte-identical to `main`
- `check.py`, `check_layer_imports`, `check_service_commits` clean; flake8 clean
- mypy 956 → **949**, with the error sets diffed line-by-line: no new errors, only removals

## Left deliberately

`postprocess_new_article` awards reputation and `postprocess_updated_article` does not, so an article published from a draft still earns its author nothing. Same shape of bug as the one fixed here, but reputation is not one of `distribute`'s sinks, and fixing it would widen this change past the sink boundary the design rests on. Recorded in the proposal as its own small change.

## Blast radius

This is the one change in the series that increases delivery volume: column subscribers now get feed rows they did not get before, and articles published from drafts now notify and fan out at all. Both are the intended fix, but they are what to watch after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)