### PR TITLE
ci: test the migrations themselves, and fix the drift that surfaced

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -5,11 +5,15 @@ name: Migrations
 # database and then test the application; nothing checked the migrations as a
 # deliverable in their own right.
 #
-# Four things are checked. What is deliberately NOT checked is a full-history
-# downgrade: `alembic downgrade base` fails today on an unnamed ForeignKey
-# constraint in an old `channel` migration, and repairing 153 migrations to fix
-# that is its own project. The round-trip below covers the case that actually
-# matters in review -- can the migration THIS pull request adds be rolled back.
+# The second half of the job runs against a *populated* database, seeded from
+# smoke/dataset.py -- the same rows the e2e smoke suite uses. An empty database
+# is the easy case; migrations break on the ones that already hold data.
+#
+# What is deliberately NOT checked is a full-history downgrade: `alembic
+# downgrade base` fails today on an unnamed ForeignKey constraint in an old
+# `channel` migration, and repairing 153 migrations to fix that is its own
+# project. The round-trip below covers the case that actually matters in
+# review -- can the migration THIS pull request adds be rolled back.
 
 on:
   pull_request:
@@ -94,9 +98,31 @@ jobs:
           fi
         '
 
-    - name: Round-trip the migrations this PR adds
+    - name: Seed the dataset
+      # An empty database is the easy case. Migrations break on populated ones:
+      # a NOT NULL column with no default, a type change that existing values
+      # do not fit, a data migration with an off-by-one. Everything below this
+      # point runs against real rows -- the same rows the e2e smoke suite uses,
+      # from smoke/dataset.py, so one definition serves both and neither
+      # silently rots.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          export PYTHONPATH=$PWD
+          python scripts/initial_data.py
+          python -m smoke.dataset build --deep
+          python -m smoke.dataset verify --deep
+        '
+
+    - name: Round-trip the migrations this PR adds, across the data
       # Only the new ones. Downgrading further hits the broken old migrations
       # described at the top of this file.
+      #
+      # The upgrade at the end is the step that matters: by then the database
+      # holds rows, so this is the production path -- applying a new migration
+      # to a populated database -- rather than the empty-schema build above.
       run: |
         set -euo pipefail
         base="${{ github.event.pull_request.base.sha }}"
@@ -119,6 +145,22 @@ jobs:
           PYTHONPATH=\$PWD alembic downgrade -$added
           PYTHONPATH=\$PWD alembic upgrade head
         "
+
+    - name: Data survived the round-trip
+      # The point of the whole job. Checks content and foreign keys, not row
+      # counts -- a migration that drops a column or breaks an FK leaves every
+      # count untouched.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          export PYTHONPATH=$PWD
+          if ! python -m smoke.dataset verify --deep; then
+            echo "::error::a migration in this PR did not preserve existing data"
+            exit 1
+          fi
+        '
 
     - name: Schema matches the models after the round-trip
       # A downgrade that silently fails to undo its upgrade leaves the schema

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,132 @@
+name: Migrations
+
+# Tests the alembic migrations themselves, rather than using them as setup for
+# something else. The other workflows all run `alembic upgrade head` to build a
+# database and then test the application; nothing checked the migrations as a
+# deliverable in their own right.
+#
+# Four things are checked. What is deliberately NOT checked is a full-history
+# downgrade: `alembic downgrade base` fails today on an unnamed ForeignKey
+# constraint in an old `channel` migration, and repairing 153 migrations to fix
+# that is its own project. The round-trip below covers the case that actually
+# matters in review -- can the migration THIS pull request adds be rolled back.
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # Full history: the round-trip step diffs against the base branch to
+        # find which migrations this PR adds.
+        fetch-depth: 0
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Setup Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
+      with:
+        use-flakehub: false
+
+    - name: Exactly one head
+      # Two heads mean two migrations claim the same parent -- the usual result
+      # of two branches each adding one. Alembic will not upgrade past it, so
+      # catching it here beats catching it on deploy.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          count=$(PYTHONPATH=$PWD alembic heads | grep -c "(head)")
+          echo "heads: $count"
+          if [ "$count" -ne 1 ]; then
+            PYTHONPATH=$PWD alembic heads
+            echo "::error::expected exactly 1 head, found $count -- merge the branches with: alembic merge heads"
+            exit 1
+          fi
+        '
+
+    - name: Build the schema from scratch
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          psql -h localhost -p 5432 -U postgres -c "create database chafan_dev;"
+          PYTHONPATH=$PWD alembic upgrade head
+        '
+
+    - name: No drift between models and migrations
+      # `alembic check` autogenerates against the just-migrated database and
+      # fails if it would produce any operation -- i.e. if a model was changed
+      # without a matching migration, or a migration does not produce what the
+      # model declares.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          if ! PYTHONPATH=$PWD alembic check; then
+            echo "::error::models and migrations disagree -- generate one with: alembic revision --autogenerate -m <message>"
+            exit 1
+          fi
+        '
+
+    - name: Round-trip the migrations this PR adds
+      # Only the new ones. Downgrading further hits the broken old migrations
+      # described at the top of this file.
+      run: |
+        set -euo pipefail
+        base="${{ github.event.pull_request.base.sha }}"
+        if [ -z "$base" ]; then
+          base="$(git rev-parse HEAD~1 2>/dev/null || true)"
+        fi
+        if [ -z "$base" ]; then
+          echo "no base commit to compare against; skipping"
+          exit 0
+        fi
+        added=$(git diff --name-only --diff-filter=A "$base" HEAD -- alembic/versions/ \
+                | grep -c '\.py$' || true)
+        echo "migrations added by this change: $added"
+        if [ "$added" -eq 0 ]; then
+          exit 0
+        fi
+        set -a; source env.ci; set +a
+        nix develop --command bash -c "
+          set -euo pipefail
+          PYTHONPATH=\$PWD alembic downgrade -$added
+          PYTHONPATH=\$PWD alembic upgrade head
+        "
+
+    - name: Schema matches the models after the round-trip
+      # A downgrade that silently fails to undo its upgrade leaves the schema
+      # subtly wrong. Re-checking after coming back up catches that.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          PYTHONPATH=$PWD alembic check
+        '

--- a/chafan_core/app/models/viewcount.py
+++ b/chafan_core/app/models/viewcount.py
@@ -4,8 +4,6 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     PrimaryKeyConstraint,
-    Table,
-    UniqueConstraint,
 )
 
 from chafan_core.db.base_class import Base
@@ -14,9 +12,17 @@ from chafan_core.db.base_class import Base
 #if TYPE_CHECKING:
 #    from . import *  # noqa: F401, F403
 
+# One row per content item, keyed by the content it counts.
+#
+# The primary key already supplies both NOT NULL and uniqueness, so these
+# columns are nullable=False and carry no separate UniqueConstraint. Declaring
+# either made the model disagree with a database that was in fact correct:
+# Postgres forces a PK column NOT NULL whatever the model says, and a
+# UniqueConstraint duplicating the PK is never materialized. `alembic check`
+# reported that disagreement as permanent drift.
+
 class ViewCountArticle(Base):
     __table_args__ = (
-        UniqueConstraint("article_id"),
         PrimaryKeyConstraint("article_id"),
     )
     article_id = Column(Integer, ForeignKey("article.id"), nullable=False, index=True)
@@ -24,24 +30,21 @@ class ViewCountArticle(Base):
 
 class ViewCountQuestion(Base):
     __table_args__ = (
-        UniqueConstraint("question_id"),
         PrimaryKeyConstraint("question_id"),
     )
-    question_id = Column(Integer, ForeignKey("question.id"), nullable=True, index=True)
+    question_id = Column(Integer, ForeignKey("question.id"), nullable=False, index=True)
     view_count = Column(Integer, default=0, server_default="0", nullable=False)
 
 class ViewCountAnswer(Base):
     __table_args__ = (
-        UniqueConstraint("answer_id"),
         PrimaryKeyConstraint("answer_id"),
     )
-    answer_id = Column(Integer, ForeignKey("answer.id"), nullable=True, index=True)
+    answer_id = Column(Integer, ForeignKey("answer.id"), nullable=False, index=True)
     view_count = Column(Integer, default=0, server_default="0", nullable=False)
 
 class ViewCountSubmission(Base):
     __table_args__ = (
-        UniqueConstraint("submission_id"),
         PrimaryKeyConstraint("submission_id"),
     )
-    submission_id = Column(Integer, ForeignKey("submission.id"), nullable=True, index=True)
+    submission_id = Column(Integer, ForeignKey("submission.id"), nullable=False, index=True)
     view_count = Column(Integer, default=0, server_default="0", nullable=False)

--- a/smoke/dataset.py
+++ b/smoke/dataset.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""The shared development dataset: build it, then assert it survived.
+
+One definition of "a database with realistic rows in it", used by two callers
+that both need one and would otherwise each grow their own:
+
+- ``smoke/seed.py`` builds it as the precondition for the e2e smoke suite,
+  then writes ``smoke/config.json`` so the scenarios can find their fixtures.
+- the ``Migrations`` workflow builds it, migrates across it, and calls
+  :func:`verify` to prove the migration preserved it.
+
+That second caller is why :func:`verify` re-queries by stable identifiers --
+email, subdomain, title -- rather than by id or by anything held in memory. It
+runs in a separate process from the build, after the schema underneath the
+rows has changed.
+
+Idempotent throughout: every ``_get_or_create_*`` reuses an existing row, so
+building twice is a no-op and a partially-seeded database converges.
+
+Usage::
+
+    PYTHONPATH=$PWD python -m smoke.dataset build [--deep]
+    PYTHONPATH=$PWD python -m smoke.dataset verify [--deep]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv  # isort:skip
+
+load_dotenv()  # isort:skip
+
+from chafan_core.app import crud, models, schemas
+from chafan_core.app.infra.request_context import RequestContext
+from chafan_core.app.schemas.event import (
+    AnswerQuestionInternal,
+    CreateQuestionInternal,
+    EventInternal,
+)
+from chafan_core.app.schemas.richtext import RichText
+from chafan_core.app.services import events
+from chafan_core.app.services import reputation as rep
+from chafan_core.db.session import SessionLocal
+from chafan_core.utils.base import ContentVisibility, get_uuid
+from chafan_core.utils.validators import (
+    StrippedNonEmptyBasicStr,
+    StrippedNonEmptyStr,
+)
+
+SITE_SUBDOMAIN = "smoke"
+SITE_NAME = "Smoke Test Site"
+COLUMN_NAME = "Smoke Test Column"
+KNOWN_QUESTION_TITLE = "Smoke test seed question"
+KNOWN_ANSWER_BODY = "Smoke test seed answer body."
+
+# Fresh users start at 0 coins (INITIAL_USER_COINS=0), but several scenarios
+# deduct coins (question/article/upvote). Grant a generous balance so the
+# write paths aren't gated on coin economics.
+TARGET_COINS = 1000
+
+ACCOUNTS = {
+    "account_a": {
+        "email": "smoke-a@cha.fan",
+        "handle": "smoke_a",
+        "full_name": "Smoke A",
+        "password": "smoke-pw-a1",
+    },
+    "account_b": {
+        "email": "smoke-b@cha.fan",
+        "handle": "smoke_b",
+        "full_name": "Smoke B",
+        "password": "smoke-pw-b1",
+    },
+}
+
+
+@dataclass
+class Dataset:
+    """What a build produced, for callers that need the ids."""
+
+    account_a: models.User
+    account_b: models.User
+    site: models.Site
+    column: models.ArticleColumn
+    question: models.Question
+    answer: Optional[models.Answer] = None
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_user(db, spec: dict):
+    user = crud.user.get_by_email(db, email=spec["email"])
+    if user:
+        return user
+    user_in = schemas.UserCreate(
+        email=spec["email"],
+        password=spec["password"],
+        handle=StrippedNonEmptyBasicStr(spec["handle"]),
+        full_name=StrippedNonEmptyStr(spec["full_name"]),
+    )
+    return crud.user.create(db, obj_in=user_in)
+
+
+def _ensure_coins(db, user) -> None:
+    if user.remaining_coins < TARGET_COINS:
+        rep.award_coins(
+            db, user, TARGET_COINS - user.remaining_coins, reason="smoke seed"
+        )
+
+
+def _get_or_create_site(db, moderator):
+    site = crud.site.get_by_subdomain(db, subdomain=SITE_SUBDOMAIN)
+    if site:
+        return site
+    site_in = schemas.SiteCreate(
+        name=StrippedNonEmptyStr(SITE_NAME),
+        subdomain=StrippedNonEmptyBasicStr(SITE_SUBDOMAIN),
+        permission_type="public",
+        description="Ephemeral site created by the bootstrap smoke seed.",
+    )
+    return crud.site.create_with_permission_type(
+        db, obj_in=site_in, moderator=moderator, category_topic_id=None
+    )
+
+
+def _ensure_membership(db, site, user):
+    existing = crud.profile.get_by_user_and_site(db, owner_id=user.id, site_id=site.id)
+    if existing:
+        return existing
+    return crud.profile.create_with_owner(
+        db,
+        obj_in=schemas.ProfileCreate(site_uuid=site.uuid, owner_uuid=user.uuid),
+    )
+
+
+def _get_or_create_column(db, owner):
+    for col in getattr(owner, "article_columns", []) or []:
+        if col.name == COLUMN_NAME:
+            return col
+    return crud.article_column.create_with_owner(
+        db,
+        obj_in=schemas.ArticleColumnCreate(name=StrippedNonEmptyStr(COLUMN_NAME)),
+        owner_id=owner.id,
+    )
+
+
+def _get_or_create_known_question(db, site, author):
+    existing = (
+        db.query(models.Question)
+        .filter_by(site_id=site.id, title=KNOWN_QUESTION_TITLE)
+        .first()
+    )
+    if existing:
+        return existing
+    return crud.question.create_with_author(
+        db,
+        obj_in=schemas.QuestionCreate(
+            site_uuid=site.uuid,
+            title=StrippedNonEmptyStr(KNOWN_QUESTION_TITLE),
+        ),
+        author_id=author.id,
+    )
+
+
+def _get_or_create_known_answer(db, question, author):
+    existing = (
+        db.query(models.Answer)
+        .filter_by(question_id=question.id, author_id=author.id)
+        .first()
+    )
+    if existing:
+        return existing
+    return crud.answer.create_with_author(
+        db,
+        obj_in=schemas.AnswerCreate(
+            question_uuid=question.uuid,
+            content=RichText(
+                source=KNOWN_ANSWER_BODY,
+                editor="tiptap",
+                rendered_text=KNOWN_ANSWER_BODY,
+            ),
+            is_published=True,
+            visibility=ContentVisibility.ANYONE,
+            writing_session_uuid=get_uuid(),
+        ),
+        author_id=author.id,
+        site_id=question.site_id,
+    )
+
+
+def _build_deep(db, data: Dataset) -> Dataset:
+    """The rows a migration is most likely to disturb: events and their sinks.
+
+    Built through ``events.distribute`` rather than by hand, so the Activity,
+    Feed and Notification rows are shaped exactly as the application makes
+    them. B follows A first, so the fan-out has somewhere to go -- without a
+    follower there would be no Feed rows and this would prove nothing.
+    """
+    crud.user.add_follower(db, db_obj=data.account_a, follower=data.account_b)
+
+    data.answer = _get_or_create_known_answer(db, data.question, author=data.account_b)
+    db.flush()
+
+    ctx = RequestContext()
+    ctx.db = db
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    if not _activities_for_verb(db, "create_question"):
+        events.distribute(
+            ctx,
+            EventInternal(
+                created_at=now,
+                content=CreateQuestionInternal(
+                    subject_id=data.account_a.id, question_id=data.question.id
+                ),
+            ),
+        )
+    if not _activities_for_verb(db, "answer_question"):
+        events.distribute(
+            ctx,
+            EventInternal(
+                created_at=now,
+                content=AnswerQuestionInternal(
+                    subject_id=data.account_b.id, answer_id=data.answer.id
+                ),
+            ),
+        )
+    return data
+
+
+def _activities_for_verb(db, verb: str) -> list:
+    return [
+        a
+        for a in db.query(models.Activity).all()
+        if f'"verb": "{verb}"' in str(a.event_json)
+        or f'"verb":"{verb}"' in str(a.event_json)
+    ]
+
+
+def build(db, *, deep: bool = False) -> Dataset:
+    """Create (or reuse) the dataset. Commits.
+
+    ``deep`` adds an answer plus the Activity/Feed/Notification rows that flow
+    from distributing its event. The smoke suite does not want those -- its
+    scenarios create their own and assert on what they find -- so it stays off
+    by default and the migration job turns it on.
+    """
+    a = _get_or_create_user(db, ACCOUNTS["account_a"])
+    b = _get_or_create_user(db, ACCOUNTS["account_b"])
+    _ensure_coins(db, a)
+    _ensure_coins(db, b)
+
+    site = _get_or_create_site(db, moderator=a)
+    _ensure_membership(db, site, a)
+    _ensure_membership(db, site, b)
+
+    column = _get_or_create_column(db, owner=a)
+    question = _get_or_create_known_question(db, site, author=a)
+    db.flush()
+
+    data = Dataset(
+        account_a=a, account_b=b, site=site, column=column, question=question
+    )
+    if deep:
+        data = _build_deep(db, data)
+
+    db.commit()
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def verify(db, *, deep: bool = False) -> None:
+    """Assert the dataset is intact. Raises AssertionError with the detail.
+
+    Checks content, not just row counts: a migration that drops a column or
+    mangles a value leaves the count untouched. Relationships are dereferenced
+    for the same reason -- a broken foreign key survives a count.
+    """
+    a = crud.user.get_by_email(db, email=ACCOUNTS["account_a"]["email"])
+    b = crud.user.get_by_email(db, email=ACCOUNTS["account_b"]["email"])
+    _require(a is not None, "account_a is gone")
+    _require(b is not None, "account_b is gone")
+    _require(
+        a.handle == ACCOUNTS["account_a"]["handle"],
+        f"account_a.handle changed: {a.handle!r}",
+    )
+    _require(
+        a.remaining_coins >= TARGET_COINS,
+        f"account_a lost coins: {a.remaining_coins}",
+    )
+    _require(a.hashed_password not in (None, ""), "account_a lost its password hash")
+
+    site = crud.site.get_by_subdomain(db, subdomain=SITE_SUBDOMAIN)
+    _require(site is not None, "site is gone")
+    _require(site.name == SITE_NAME, f"site.name changed: {site.name!r}")
+    _require(site.moderator_id == a.id, "site lost its moderator FK")
+
+    for user in (a, b):
+        profile = crud.profile.get_by_user_and_site(
+            db, owner_id=user.id, site_id=site.id
+        )
+        _require(profile is not None, f"membership for {user.handle} is gone")
+
+    question = (
+        db.query(models.Question)
+        .filter_by(site_id=site.id, title=KNOWN_QUESTION_TITLE)
+        .first()
+    )
+    _require(question is not None, "known question is gone")
+    _require(question.author_id == a.id, "question lost its author FK")
+    _require(question.site.subdomain == SITE_SUBDOMAIN, "question lost its site FK")
+
+    column = next(
+        (c for c in (a.article_columns or []) if c.name == COLUMN_NAME), None
+    )
+    _require(column is not None, "article column is gone")
+
+    if not deep:
+        return
+
+    answer = (
+        db.query(models.Answer).filter_by(question_id=question.id, author_id=b.id).first()
+    )
+    _require(answer is not None, "known answer is gone")
+    _require(
+        KNOWN_ANSWER_BODY in str(answer.body), f"answer body changed: {answer.body!r}"
+    )
+
+    _require(a in b.followed, "the follow edge is gone")
+
+    for verb in ("create_question", "answer_question"):
+        activities = _activities_for_verb(db, verb)
+        _require(activities, f"no Activity survived for {verb}")
+        for activity in activities:
+            _require(
+                activity.event_json not in (None, ""),
+                f"{verb} Activity lost its payload",
+            )
+
+    feeds = db.query(models.Feed).count()
+    _require(feeds > 0, "every Feed row is gone")
+    for feed in db.query(models.Feed).all():
+        _require(feed.activity is not None, "a Feed row lost its Activity FK")
+
+    notifications = db.query(models.Notification).count()
+    _require(notifications > 0, "every Notification row is gone")
+
+
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("build", "verify"))
+    parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="include the answer and the Activity/Feed/Notification rows",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    if args.action == "build":
+        data = build(db, deep=args.deep)
+        print(f"dataset built  site={data.site.subdomain!r} question={data.question.uuid}")
+        if args.deep:
+            print(f"dataset built  answer={data.answer.uuid}")
+        return 0
+
+    try:
+        verify(db, deep=args.deep)
+    except AssertionError as exc:
+        print(f"dataset VERIFY FAILED: {exc}", file=sys.stderr)
+        return 1
+    print("dataset verified: intact")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/smoke/seed.py
+++ b/smoke/seed.py
@@ -1,21 +1,16 @@
 #!/usr/bin/env python3
 """Bootstrap-mode seed for the smoke suite.
 
-Populates a *fresh* dev database with the minimum fixtures the smoke
-scenarios assume already exist against production:
+Builds the shared development dataset (:mod:`smoke.dataset`) and writes
+``smoke/config.json`` so ``run_all.py`` can run unchanged. The rows themselves
+are defined in that module, because the ``Migrations`` workflow needs the same
+ones to test that a migration preserves data.
 
-  - two member accounts (A and B),
-  - a public site both accounts belong to,
-  - an article column owned by A,
-  - one public question (the "known question" s02 reads anonymously).
-
-then writes ``smoke/config.json`` so ``run_all.py`` can run unchanged.
-
-This talks to the DB directly through the crud layer (same pattern as
-``scripts/initial_data.py``) rather than driving the public registration
-API: open-account requires an invitation link + emailed verification code,
-which is friction we don't want in CI. The scenarios themselves still
-exercise the HTTP API end-to-end; this only establishes preconditions.
+The dataset talks to the DB directly through the crud layer (same pattern as
+``scripts/initial_data.py``) rather than driving the public registration API:
+open-account requires an invitation link + emailed verification code, which is
+friction we don't want in CI. The scenarios themselves still exercise the HTTP
+API end-to-end; this only establishes preconditions.
 
 Run from the repo root with the app importable, e.g.::
 
@@ -34,141 +29,27 @@ from dotenv import load_dotenv  # isort:skip
 
 load_dotenv()  # isort:skip
 
-from chafan_core.app import crud, models, schemas
-from chafan_core.app.services import reputation as rep
 from chafan_core.db.session import SessionLocal
-from chafan_core.utils.validators import (
-    StrippedNonEmptyBasicStr,
-    StrippedNonEmptyStr,
-)
+from smoke.dataset import ACCOUNTS, build
 
 API_BASE = os.environ.get("SMOKE_API_BASE", "http://127.0.0.1:8000")
 # Generous for a cold CI runner: s10/s11 poll post-response fan-out.
 POLL_TIMEOUT_SECONDS = int(os.environ.get("SMOKE_POLL_TIMEOUT_SECONDS", "60"))
 
-SITE_SUBDOMAIN = "smoke"
-SITE_NAME = "Smoke Test Site"
-COLUMN_NAME = "Smoke Test Column"
-KNOWN_QUESTION_TITLE = "Smoke test seed question"
-# Fresh users start at 0 coins (INITIAL_USER_COINS=0), but several scenarios
-# deduct coins (question/article/upvote). Grant a generous balance so the
-# write paths aren't gated on coin economics.
-TARGET_COINS = 1000
-
-ACCOUNTS = {
-    "account_a": {
-        "email": "smoke-a@cha.fan",
-        "handle": "smoke_a",
-        "full_name": "Smoke A",
-        "password": "smoke-pw-a1",
-    },
-    "account_b": {
-        "email": "smoke-b@cha.fan",
-        "handle": "smoke_b",
-        "full_name": "Smoke B",
-        "password": "smoke-pw-b1",
-    },
-}
-
-
-def _get_or_create_user(db, spec: dict):
-    user = crud.user.get_by_email(db, email=spec["email"])
-    if user:
-        return user
-    user_in = schemas.UserCreate(
-        email=spec["email"],
-        password=spec["password"],
-        handle=StrippedNonEmptyBasicStr(spec["handle"]),
-        full_name=StrippedNonEmptyStr(spec["full_name"]),
-    )
-    return crud.user.create(db, obj_in=user_in)
-
-
-def _ensure_coins(db, user) -> None:
-    if user.remaining_coins < TARGET_COINS:
-        rep.award_coins(
-            db, user, TARGET_COINS - user.remaining_coins, reason="smoke seed"
-        )
-        db.commit()
-
-
-def _get_or_create_site(db, moderator):
-    site = crud.site.get_by_subdomain(db, subdomain=SITE_SUBDOMAIN)
-    if site:
-        return site
-    site_in = schemas.SiteCreate(
-        name=StrippedNonEmptyStr(SITE_NAME),
-        subdomain=StrippedNonEmptyBasicStr(SITE_SUBDOMAIN),
-        permission_type="public",
-        description="Ephemeral site created by the bootstrap smoke seed.",
-    )
-    return crud.site.create_with_permission_type(
-        db, obj_in=site_in, moderator=moderator, category_topic_id=None
-    )
-
-
-def _ensure_membership(db, site, user):
-    existing = crud.profile.get_by_user_and_site(
-        db, owner_id=user.id, site_id=site.id
-    )
-    if existing:
-        return existing
-    return crud.profile.create_with_owner(
-        db,
-        obj_in=schemas.ProfileCreate(site_uuid=site.uuid, owner_uuid=user.uuid),
-    )
-
-
-def _get_or_create_column(db, owner):
-    for col in getattr(owner, "article_columns", []) or []:
-        if col.name == COLUMN_NAME:
-            return col
-    return crud.article_column.create_with_owner(
-        db,
-        obj_in=schemas.ArticleColumnCreate(name=StrippedNonEmptyStr(COLUMN_NAME)),
-        owner_id=owner.id,
-    )
-
-
-def _get_or_create_known_question(db, site, author):
-    existing = (
-        db.query(models.Question)
-        .filter_by(site_id=site.id, title=KNOWN_QUESTION_TITLE)
-        .first()
-    )
-    if existing:
-        return existing
-    return crud.question.create_with_author(
-        db,
-        obj_in=schemas.QuestionCreate(
-            site_uuid=site.uuid,
-            title=StrippedNonEmptyStr(KNOWN_QUESTION_TITLE),
-        ),
-        author_id=author.id,
-    )
-
 
 def main() -> None:
     db = SessionLocal()
 
-    a = _get_or_create_user(db, ACCOUNTS["account_a"])
-    b = _get_or_create_user(db, ACCOUNTS["account_b"])
-    _ensure_coins(db, a)
-    _ensure_coins(db, b)
-
-    site = _get_or_create_site(db, moderator=a)
-    _ensure_membership(db, site, a)
-    _ensure_membership(db, site, b)
-
-    column = _get_or_create_column(db, owner=a)
-    question = _get_or_create_known_question(db, site, author=a)
-    db.commit()
+    # deep=False: the scenarios create their own answers, activities and
+    # notifications and assert on what they find. Pre-seeding those would be
+    # noise they have to work around.
+    data = build(db, deep=False)
 
     config = {
         "api_base": API_BASE,
-        "site": site.subdomain,
-        "article_column_uuid": column.uuid,
-        "known_question_uuid": question.uuid,
+        "site": data.site.subdomain,
+        "article_column_uuid": data.column.uuid,
+        "known_question_uuid": data.question.uuid,
         "poll_timeout_seconds": POLL_TIMEOUT_SECONDS,
         "account_a": {
             "username": ACCOUNTS["account_a"]["email"],
@@ -183,9 +64,9 @@ def main() -> None:
     out = pathlib.Path(__file__).resolve().parent / "config.json"
     out.write_text(json.dumps(config, indent=2) + "\n")
 
-    print(f"seed OK  site={site.subdomain!r} uuid={site.uuid}")
-    print(f"seed OK  column uuid={column.uuid}")
-    print(f"seed OK  known question uuid={question.uuid}")
+    print(f"seed OK  site={data.site.subdomain!r} uuid={data.site.uuid}")
+    print(f"seed OK  column uuid={data.column.uuid}")
+    print(f"seed OK  known question uuid={data.question.uuid}")
     print(f"seed OK  wrote {out}")
 
 


### PR DESCRIPTION
Groundwork for step 4, which needs a schema change (`activity.subject_user_id`). Before writing migrations against 153 old ones, it seemed worth knowing whether the existing ones are sound.

## What was missing

Every workflow already runs `alembic upgrade head` — but only ever as *setup* for testing something else. Nothing checked the migrations as a deliverable. A model changed without a migration, or two branches each adding one and producing two heads, would have reached deploy.

The new job checks four things:

| Check | Why |
|---|---|
| exactly one head | alembic refuses to upgrade past two; the usual cause is a merge nobody noticed |
| schema builds from scratch | the empty-database path, on its own rather than incidental to a test run |
| `alembic check` | no drift between models and migrations |
| round-trip of new migrations | the migrations *this PR adds* downgrade and upgrade again, with a second `check` after |

That last `check` is the one that earns its place: a downgrade which silently fails to undo its upgrade leaves the schema subtly wrong, and coming back up clean is the only way to see it.

## What is deliberately not checked

**A full-history downgrade.** `alembic downgrade base` fails today:

```
sqlalchemy.exc.CompileError: Can't emit DROP CONSTRAINT for constraint
ForeignKeyConstraint(..., table=Table('channel', ...)); it has no name
```

Repairing that across 153 migrations is its own project. The round-trip covers the case that actually comes up in review — *can the migration in front of me be rolled back* — without pretending the whole history is reversible.

## The drift it found immediately

`alembic check` failed on `main` the first time it ran, on all four `viewcount` tables. **The database was correct and the models were not.** They declared:

- `nullable=True` on a **primary key** column — Postgres makes it `NOT NULL` regardless
- a `UniqueConstraint` duplicating the primary key — never materialized

So autogenerate saw a difference on every single run that no migration could ever resolve. Verified against the live table:

```
 answer_id  | integer | not null
Indexes:
    "viewcountanswer_pkey" PRIMARY KEY, btree (answer_id)
```

Fixed in the models, which is where the error was. **No migration, no DDL, schema untouched** — the PK already supplies both the NOT NULL and the uniqueness the models were trying to declare twice.

## Verification

All four steps were run locally against a scratch database, including staging a throwaway migration to confirm the round-trip works *and* that the post-round-trip `check` catches a column left behind.

- 432 passed / 9 skipped
- mypy unchanged at 949, `check.py` / layer-imports / service-commits / flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)