### PR TITLE
docs: plan the Activity/Feed responsibility reassignment (step 4, item 1)

### DIFF
--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -1,0 +1,188 @@
+# Activity as the event log, Feed as a receiver index
+
+**Status:** proposed | **Date:** 2026-08-04 | **Last reviewed:** 2026-08-04
+
+Step 4, item 1 of the activity/feed work. Steps 1–3 landed in #166, #167, #168
+and #169; the seam they built (`services/events.py`) is what makes this
+tractable. Terminology is in [`docs/glossary.md`](../glossary.md).
+
+## The problem
+
+`Feed` is a delivery record: one row per `(activity, receiver)`. `Activity` is
+the event log. Today the *subject* timeline — "show me everything this user
+did", the profile page — is served out of `Feed`:
+
+```python
+if subject_user_uuid is not None:
+    feeds = feeds.filter_by(subject_user_uuid=subject_user_uuid)
+else:
+    feeds = feeds.filter_by(receiver_id=receiver_user_id)
+```
+[`feed_impl.py:144`](../../chafan_core/app/services/feed_impl.py)
+
+The subject branch ignores `receiver_id` entirely, and asks the delivery table a
+question about authorship. Three consequences, all live:
+
+**Duplicates are structural.** A user with 200 followers produces 200 `Feed`
+rows per activity, so the same activity comes back 200 times. Hence the
+`limit * 2` over-fetch and the `activity_ids` seen-set at `feed_impl.py:150-161`
+— machinery that exists only to undo the fan-out the query just read.
+
+**A user with no audience has an empty profile.** No followers and no column
+subscribers means no `Feed` rows, so the profile timeline is blank no matter how
+much the user has posted. This is the bug in its plainest form.
+
+**`Feed` carries a column it should not.** `subject_user_uuid` is denormalized
+onto every delivery row purely to make that filter possible
+([`models/feed.py:26`](../../chafan_core/app/models/feed.py)).
+
+The now-dead v1 `get_activities` shows what this forced. Viewing your own
+profile swapped in the *superuser's* receiver id:
+
+```python
+if receiver.uuid == subject_user_uuid:
+    receiver_id = crud.user.get_superuser(db).id
+```
+[`feed_impl.py:180`](../../chafan_core/app/services/feed_impl.py)
+
+— because you do not follow yourself, so you have no `Feed` rows for your own
+activity, so your own profile would otherwise be blank. A workaround for
+exactly the defect above.
+
+## The target
+
+Two tables, two responsibilities, neither borrowed:
+
+- **`Activity`** — the complete event log, and the source for *subject*
+  queries. One row per event.
+- **`Feed`** — a pure receiver index. `(activity_id, receiver_id)` and nothing
+  else.
+
+## Why this needs a schema change
+
+`Activity` has no subject column. The subject exists only inside `event_json`,
+which is `Column(String)` — plain text, not `JSON`/`JSONB`
+([`models/activity.py:22`](../../chafan_core/app/models/activity.py)). So
+"activities whose subject is user X" is not expressible in SQL today except as
+a full scan with a per-row parse, which is worse than the query it replaces.
+
+The addition is one column:
+
+```
+activity.subject_user_id   -- nullable, FK to user.id, indexed
+```
+
+Nullable because exactly one content type has no subject: `site_broadcast`. The
+other 31 of 32 `*Internal` content classes carry `subject_id`.
+
+The alternative — converting `event_json` to `JSONB` with an expression index —
+avoids the column but is a type migration on the largest table and yields no
+foreign key. Not worth it.
+
+## The safety property, verified
+
+Switching the subject query from `Feed` to `Activity` widens what the query
+*returns*: previously only activities that had been delivered to somebody, now
+everything the subject did. That is the fix, but it raises the obvious
+question — does it expose activity from sites the viewer cannot read?
+
+**No.** Delivery has never been what grants visibility. `materialize_activity`
+resolves the event per *viewer*, and the responder gate is a site membership
+check:
+
+```python
+if not user_permission.user_in_site(
+    db, site=question.site, user_id=principal_id, op_type=OperationType.ReadSite,
+):
+    return None
+```
+[`responders/question.py:63`](../../chafan_core/app/responders/question.py)
+
+`materialize_event` returns `None` when a preview is `None`, so
+`materialize_activity` returns `None` and the item silently does not render.
+Same guarantee the event-distribution design already rests on: a `Feed` row
+grants nothing, and now neither does an `Activity` row.
+
+The one path where that guarantee does *not* hold is
+`feed_impl.retrieve_content`, the RSS path — tracked separately as
+[#170](https://github.com/chafan-dev/chafan-core/issues/170) and untouched by
+this work.
+
+## Steps
+
+Each is independently deployable and independently revertible. Steps 1–3 change
+no behavior at all.
+
+**1. Add the column.** Migration adding `activity.subject_user_id`, nullable,
+indexed, FK to `user.id`. Nothing reads or writes it yet. Proven by the
+migrations CI added in #171: builds from scratch, no drift, round-trips.
+
+**2. Populate it on write.** `events.distribute` already derives the subject —
+`deliver()` resolves `subject_id` from the event content to set
+`Feed.subject_user_uuid`. The same derivation sets the new column when the
+`Activity` is constructed. New rows are complete from here on; old rows are
+still null.
+
+**3. Backfill.** Parse `event_json` for every row where `subject_user_id IS
+NULL`, extract `subject_id`, write it. Batched and idempotent, so it can be run,
+interrupted, and re-run. Note this is a *different* kind of migration from the
+one declined in 3b: that was refusing to **correct** wrong rows, this
+**derives** a column from data that is already right. Size it first:
+
+```sql
+SELECT count(*) FROM activity;
+```
+
+**4. Switch the read path.** `get_activities_v2` splits in two, because they
+were always two questions:
+
+| Query | Reads | Ordered by |
+|---|---|---|
+| receiver feed (`subject_user_uuid is None`) | `Feed` by `receiver_id` | `activity_id desc` |
+| subject timeline | `Activity` by `subject_user_id` | `id desc` |
+
+The subject branch needs no dedup, no `limit * 2`, and works for a user with no
+audience. Both still materialize per viewer, so the gate above is unchanged.
+This is the step where the bug is fixed and the only one with a behavior change.
+
+**5. Delete the dead v1.** `get_activities` has no callers and is already marked
+`# TODO to remove this function`. Same category as `new_activity_into_feed`,
+which #169 deleted.
+
+**6. Deferred — drop `feed.subject_user_uuid`.** Destructive DDL, and
+contingent on step 4 item 2 (fan-out-on-write vs read-time resolution): under
+read-time resolution there may be no `Feed` rows at all, which makes the column
+moot rather than merely redundant. Hold until that is decided.
+
+## What changes for users
+
+Profile timelines start showing everything the subject did that the viewer is
+allowed to see, rather than only what happened to be delivered to somebody.
+For an active user with followers the result is nearly identical, minus the
+duplicates. For a user with no followers it goes from empty to complete.
+
+This is the intended fix, but it is a visible product change and worth
+confirming before step 4 ships.
+
+## Verification
+
+Per step: full unit suite, byte-identical OpenAPI (the endpoint signature does
+not change at any point), both architecture ratchets, mypy flat, and the
+migrations CI from #171.
+
+Two tests the change should carry:
+
+- A user with **no followers and no column subscribers** has a non-empty
+  profile timeline. This fails today and is the point of the change.
+- A viewer who cannot read a private site does **not** see the subject's
+  activity from that site, even though the `Activity` row is now reachable by
+  the query. Pins the safety property above.
+
+## Open questions
+
+- **Backfill size.** Unknown without `count(*)` against production. It sets
+  whether step 3 is a single statement or a batched script.
+- **Does the subject timeline want a site filter of its own?** Today the viewer
+  gate is per item, applied after the fetch, so a subject with lots of activity
+  in sites the viewer cannot read yields a short page rather than an empty one.
+  Acceptable, but it is a pagination wrinkle worth knowing about.

--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -72,12 +72,49 @@ The addition is one column:
 activity.subject_user_id   -- nullable, FK to user.id, indexed
 ```
 
-Nullable because exactly one content type has no subject: `site_broadcast`. The
-other 31 of 32 `*Internal` content classes carry `subject_id`.
-
 The alternative — converting `event_json` to `JSONB` with an expression index —
 avoids the column but is a type migration on the largest table and yields no
 foreign key. Not worth it.
+
+### Why nullable
+
+An earlier draft of this plan said "nullable because `site_broadcast` has no
+subject". That was wrong, and checking it is what produced the rule below.
+`site_broadcast` has no live emitter and `writes_activity=False`, so it never
+reaches the `Activity` table at all. Checked mechanically against the policy
+table and the event schemas:
+
+> **Every one of the 15 verbs that writes an `Activity` carries `subject_id`.**
+> None are missing it.
+
+So on today's code the column would in fact always be populated. It is still
+declared nullable, for two reasons that have nothing to do with any verb:
+
+- **The deploy is two-phase.** Step 1 adds the column before step 3 fills it.
+  Between those, every existing row is null.
+- **Historical rows may not backfill.** The table holds rows written by code
+  that no longer exists. Any whose payload will not parse, or whose
+  `subject_id` points at a since-deleted user, cannot be filled and must be
+  allowed to stay null rather than block the migration.
+
+Tightening to `NOT NULL` is a later, separate decision, available once a
+backfill has run and `SELECT count(*) FROM activity WHERE subject_user_id IS
+NULL` is zero. Not part of this plan.
+
+### `site_broadcast`
+
+Low priority, and undecided between removal and refactor — so this plan does
+not try to make it correct. It only guarantees it cannot break anything, which
+costs nothing here because the null-tolerant design above already covers it:
+
+- a content object with no `subject_id` yields `None` from `_attr`, so step 2
+  writes a null and does not raise;
+- the backfill skips what it cannot parse rather than aborting (see step 3);
+- a null-subject row simply never appears in a subject query.
+
+If `site_broadcast` ever gains an emitter, the worst outcome is that its
+activities do not show on anyone's profile. That is a correctness gap in a
+component already slated for a decision, not an outage.
 
 ## The safety property, verified
 
@@ -114,8 +151,10 @@ Each is independently deployable and independently revertible. Steps 1–3 chang
 no behavior at all.
 
 **1. Add the column.** Migration adding `activity.subject_user_id`, nullable,
-indexed, FK to `user.id`. Nothing reads or writes it yet. Proven by the
-migrations CI added in #171: builds from scratch, no drift, round-trips.
+indexed, FK to `user.id`. Nothing reads or writes it yet. Covered by the
+migrations CI (#171, extended in #173): one head, builds from scratch, no
+model/migration drift, and a downgrade/upgrade round-trip across a *populated*
+database with the seeded rows verified afterwards.
 
 **2. Populate it on write.** `events.distribute` already derives the subject —
 `deliver()` resolves `subject_id` from the event content to set
@@ -132,6 +171,21 @@ one declined in 3b: that was refusing to **correct** wrong rows, this
 ```sql
 SELECT count(*) FROM activity;
 ```
+
+**It must skip, not abort.** A row whose payload will not parse, or whose
+`subject_id` names a user that no longer exists, is left null and logged. One
+unreadable row from some retired code path must not fail the migration for the
+whole table — the same reasoning as 3b-1, one layer down.
+
+The migrations CI exercises this for real: its seeded dataset builds
+`Activity` rows through `events.distribute`, so a backfill runs against genuine
+`event_json` and `verify` fails if it mangles them.
+
+Coverage is thin, though — the dataset distributes only `create_question` and
+`answer_question`, 2 of the 15 verbs that write activities. All 15 store
+`subject_id` the same way, so one extraction handles them all and the risk is
+lower than the count suggests, but broadening the seeded verbs before this step
+lands would make the test mean what it appears to mean.
 
 **4. Switch the read path.** `get_activities_v2` splits in two, because they
 were always two questions:
@@ -168,20 +222,26 @@ confirming before step 4 ships.
 
 Per step: full unit suite, byte-identical OpenAPI (the endpoint signature does
 not change at any point), both architecture ratchets, mypy flat, and the
-migrations CI from #171.
+migrations CI (#171, #173).
 
-Two tests the change should carry:
+Three tests the change should carry:
 
 - A user with **no followers and no column subscribers** has a non-empty
   profile timeline. This fails today and is the point of the change.
 - A viewer who cannot read a private site does **not** see the subject's
   activity from that site, even though the `Activity` row is now reachable by
   the query. Pins the safety property above.
+- An `Activity` whose payload has no resolvable subject is **skipped, not
+  fatal** — it backfills to null, writes to null, and is absent from subject
+  queries. Pins the containment described under "Why nullable".
 
 ## Open questions
 
 - **Backfill size.** Unknown without `count(*)` against production. It sets
   whether step 3 is a single statement or a batched script.
+- **Widen the seeded verbs before step 3?** The migrations CI dataset covers 2
+  of the 15 activity-writing verbs. Cheap to extend, and it is what makes the
+  backfill test load-bearing rather than decorative.
 - **Does the subject timeline want a site filter of its own?** Today the viewer
   gate is per item, applied after the fetch, so a subject with lots of activity
   in sites the viewer cannot read yields a short page rather than an empty one.

--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -1,10 +1,11 @@
 # Activity as the event log, Feed as a receiver index
 
-**Status:** proposed | **Date:** 2026-08-04 | **Last reviewed:** 2026-08-04
+**Status:** proposed | **Date:** 2026-08-04 | **Last reviewed:** 2026-08-05
 
 Step 4, item 1 of the activity/feed work. Steps 1–3 landed in #166, #167, #168
 and #169; the seam they built (`services/events.py`) is what makes this
-tractable. Terminology is in [`docs/glossary.md`](../glossary.md).
+tractable. The migrations CI this plan's schema change relies on landed in #171
+and #173. Terminology is in [`docs/glossary.md`](../glossary.md).
 
 ## The problem
 
@@ -78,11 +79,11 @@ foreign key. Not worth it.
 
 ### Why nullable
 
-An earlier draft of this plan said "nullable because `site_broadcast` has no
-subject". That was wrong, and checking it is what produced the rule below.
-`site_broadcast` has no live emitter and `writes_activity=False`, so it never
-reaches the `Activity` table at all. Checked mechanically against the policy
-table and the event schemas:
+Not because some verb lacks a subject — the tempting answer, and the wrong one.
+`site_broadcast` is the only content type without `subject_id`, but it has no
+live emitter and `writes_activity=False`, so it never reaches the `Activity`
+table at all. Checked mechanically against the policy table and the event
+schemas:
 
 > **Every one of the 15 verbs that writes an `Activity` carries `subject_id`.**
 > None are missing it.
@@ -181,11 +182,13 @@ The migrations CI exercises this for real: its seeded dataset builds
 `Activity` rows through `events.distribute`, so a backfill runs against genuine
 `event_json` and `verify` fails if it mangles them.
 
-Coverage is thin, though — the dataset distributes only `create_question` and
-`answer_question`, 2 of the 15 verbs that write activities. All 15 store
-`subject_id` the same way, so one extraction handles them all and the risk is
-lower than the count suggests, but broadening the seeded verbs before this step
-lands would make the test mean what it appears to mean.
+Coverage is thin, though — `_build_deep` in
+[`smoke/dataset/__init__.py`](../../smoke/dataset/__init__.py) distributes only
+`create_question` and `answer_question`, 2 of the 15 verbs that write
+activities. All 15 store `subject_id` the same way, so one extraction handles
+them all and the risk is lower than the count suggests, but broadening the
+seeded verbs before this step lands would make the test mean what it appears to
+mean.
 
 **4. Switch the read path.** `get_activities_v2` splits in two, because they
 were always two questions:
@@ -198,6 +201,22 @@ were always two questions:
 The subject branch needs no dedup, no `limit * 2`, and works for a user with no
 audience. Both still materialize per viewer, so the gate above is unchanged.
 This is the step where the bug is fixed and the only one with a behavior change.
+
+**The identifier changes type here, which is easy to miss.** The API takes
+`subject_user_uuid: Optional[str]`
+([`endpoints/activities.py:47`](../../chafan_core/app/api/api_v1/endpoints/activities.py)),
+and `Feed.subject_user_uuid` is a `CHAR` column, so today the parameter reaches
+the query unchanged. `Activity.subject_user_id` is an integer FK, so the subject
+branch has to resolve the uuid to a user first. Two consequences worth deciding
+deliberately rather than discovering:
+
+- a uuid that names no user returns an **empty timeline**, not an error — it is
+  a reader asking about somebody who is gone, not a malformed request;
+- that lookup is one extra query per call, which is why it belongs in the
+  subject branch only and not above the split.
+
+Keeping the API parameter a uuid is deliberate: it is the public identifier and
+changing it would break clients for no gain.
 
 **5. Delete the dead v1.** `get_activities` has no callers and is already marked
 `# TODO to remove this function`. Same category as `new_activity_into_feed`,
@@ -239,9 +258,9 @@ Three tests the change should carry:
 
 - **Backfill size.** Unknown without `count(*)` against production. It sets
   whether step 3 is a single statement or a batched script.
-- **Widen the seeded verbs before step 3?** The migrations CI dataset covers 2
-  of the 15 activity-writing verbs. Cheap to extend, and it is what makes the
-  backfill test load-bearing rather than decorative.
+- **Widen the seeded verbs before step 3?** `_build_deep` covers 2 of the 15
+  activity-writing verbs. Cheap to extend, and it is what makes the backfill
+  test load-bearing rather than decorative.
 - **Does the subject timeline want a site filter of its own?** Today the viewer
   gate is per item, applied after the fetch, so a subject with lots of activity
   in sites the viewer cannot read yields a short page rather than an empty one.


### PR DESCRIPTION
Plan only — no code. Depends on #171 (migrations CI) for the schema step.

## The problem

The subject timeline — the profile page — is served out of the **delivery** table:

```python
if subject_user_uuid is not None:
    feeds = feeds.filter_by(subject_user_uuid=subject_user_uuid)   # ignores receiver
else:
    feeds = feeds.filter_by(receiver_id=receiver_user_id)
```

Three live consequences:

- **Duplicates are structural.** 200 followers → 200 `Feed` rows per activity → the same activity 200 times. The `limit * 2` over-fetch and the `activity_ids` seen-set exist only to undo the fan-out the query just read.
- **A user with no audience has an empty profile**, however much they have posted.
- **`Feed` carries `subject_user_uuid`** purely to make that filter possible.

The dead v1 `get_activities` shows what this forced — viewing your own profile swapped in the *superuser's* receiver id, because you do not follow yourself.

## The plan

Six steps, first three behavior-neutral, each independently revertible:

1. Add `activity.subject_user_id` — nullable, indexed, FK. Nullable because `site_broadcast` is the one content type of 32 with no subject.
2. Populate on write, reusing the derivation `distribute` already does for `Feed.subject_user_uuid`.
3. Backfill from `event_json`, batched and idempotent.
4. **Split the read path** — `Feed` by receiver for the feed, `Activity` by subject for the timeline. No dedup, no over-fetch, works with zero followers. This is where the bug is fixed.
5. Delete the dead v1 `get_activities`.
6. *Deferred:* drop `feed.subject_user_uuid` — destructive, and contingent on the fan-out-vs-read-time question.

## Why a schema change is unavoidable

`Activity.event_json` is `Column(String)` — plain text, not `JSONB`. The subject exists only inside it, so "activities whose subject is X" is not expressible in SQL without a full scan and per-row parse, which is worse than the query it replaces.

## The safety property, verified

Step 4 widens what the subject query returns: previously only activities delivered to somebody, now everything the subject did. The obvious review concern is whether that exposes private-site activity. **It does not** — and I checked rather than assuming:

```python
if not user_permission.user_in_site(
    db, site=question.site, user_id=principal_id, op_type=OperationType.ReadSite,
):
    return None
```

`materialize_event` returns `None` when a preview is `None`, so the item silently does not render. Same guarantee the event-distribution design already rests on: delivery was never what granted visibility. The one path where it does *not* hold is the RSS dereference — #170, untouched here.

## What changes for users

Profile timelines show everything the subject did that the viewer may see, rather than only what was delivered to somebody. Near-identical for an active user with followers, minus duplicates; empty → complete for a user with none. Intended, but a visible product change worth confirming before step 4 ships.

## Open question I could not answer from here

**Backfill size** — needs `SELECT count(*) FROM activity;` against production. It decides whether step 3 is one statement or a batched script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)