### PR TITLE
activity: add the subject column (step 1)

### DIFF
--- a/alembic/versions/7a670908f3fa_add_activity_subject_user_id.py
+++ b/alembic/versions/7a670908f3fa_add_activity_subject_user_id.py
@@ -1,0 +1,45 @@
+"""Add activity.subject_user_id
+
+Step 1 of docs/proposals/2026-08-04-activity-feed-reassignment.md: give
+Activity a subject column so subject timelines can be answered from the event
+log instead of the delivery table. Nothing reads or writes it yet; steps 2 and
+3 populate it.
+
+Nullable on purpose. Every verb that writes an Activity today carries a
+subject, but the deploy is two-phase (rows exist before step 2 fills them) and
+historical rows whose payload will not parse must be allowed to stay null
+rather than block the migration.
+
+Revision ID: 7a670908f3fa
+Revises: dd8d1f4a6434
+Create Date: 2026-08-05 15:17:19.960392
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7a670908f3fa'
+down_revision = 'dd8d1f4a6434'
+branch_labels = None
+depends_on = None
+
+# Named, rather than the `None` autogenerate emits and most migrations here
+# keep. An unnamed constraint leaves the downgrade with no name to drop -- the
+# same defect that makes `alembic downgrade base` fail on the old `channel`
+# migration (see .github/workflows/migrations.yml). The value below is what
+# Postgres would have chosen anyway.
+FK_NAME = "activity_subject_user_id_fkey"
+
+
+def upgrade():
+    op.add_column('activity', sa.Column('subject_user_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_activity_subject_user_id'), 'activity', ['subject_user_id'], unique=False)
+    op.create_foreign_key(FK_NAME, 'activity', 'user', ['subject_user_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint(FK_NAME, 'activity', type_='foreignkey')
+    op.drop_index(op.f('ix_activity_subject_user_id'), table_name='activity')
+    op.drop_column('activity', 'subject_user_id')

--- a/chafan_core/app/models/activity.py
+++ b/chafan_core/app/models/activity.py
@@ -20,3 +20,11 @@ class Activity(Base):
     site: Optional["Site"] = relationship("Site", foreign_keys=[site_id])  # type: ignore
     created_at = Column(DateTime(timezone=True), nullable=False, index=True)
     event_json = Column(String, nullable=False)
+
+    # Who the event is about, lifted out of event_json so subject timelines are
+    # expressible in SQL. Nullable for the two-phase deploy (rows written before
+    # this column existed) and for historical rows a backfill cannot resolve --
+    # not because any verb lacks a subject. See
+    # docs/proposals/2026-08-04-activity-feed-reassignment.md.
+    subject_user_id = Column(Integer, ForeignKey("user.id"), index=True, nullable=True)
+    subject_user: Optional["User"] = relationship("User", foreign_keys=[subject_user_id])  # type: ignore

--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -151,7 +151,8 @@ this work.
 Each is independently deployable and independently revertible. Steps 1–3 change
 no behavior at all.
 
-**1. Add the column.** Migration adding `activity.subject_user_id`, nullable,
+**1. Add the column. — done, `7a670908f3fa`.** Migration adding
+`activity.subject_user_id`, nullable,
 indexed, FK to `user.id`. Nothing reads or writes it yet. Covered by the
 migrations CI (#171, extended in #173): one head, builds from scratch, no
 model/migration drift, and a downgrade/upgrade round-trip across a *populated*


### PR DESCRIPTION
Step 1 of [the activity/feed reassignment plan](https://github.com/chafan-dev/chafan-core/blob/main/docs/proposals/2026-08-04-activity-feed-reassignment.md) (#172). Steps 1–3 change no behavior; this is the schema-only one.

## Why

`Activity` has no subject column — the subject lives inside `event_json`, which is `Column(String)`. So "activities whose subject is user X" is not expressible in SQL, which is why the subject timeline (the profile page) is served out of `Feed`, the *delivery* table. That is what makes duplicates structural, forces the `limit * 2` over-fetch and seen-set, and leaves a user with no followers staring at an empty profile.

## What

One column: `activity.subject_user_id` — nullable, indexed, FK to `user.id`. Nothing reads or writes it yet. Step 2 populates it on write, step 3 backfills, step 4 switches the read path and fixes the bug.

**Nullable is about the deploy, not about any verb.** All 15 verbs that write an `Activity` carry `subject_id`; none are missing it. The column is null between step 1 and step 3, and historical rows whose payload will not parse must be allowed to stay null rather than block the backfill. Tightening to `NOT NULL` is a separate decision available once a backfill has run.

**The migration names its FK constraint** instead of passing `None` as the surrounding migrations do. An unnamed constraint leaves the downgrade with no name to drop — the same defect that makes `alembic downgrade base` fail on the old `channel` migration — and the migrations CI (#171) round-trips this PR's downgrade. The name is what Postgres would have chosen anyway.

## Verification

The migrations job reproduced locally against a **populated** database:

- one head; builds from scratch
- `alembic check` clean — no model/migration drift
- `alembic downgrade -1 && alembic upgrade head` across the seeded `--deep` dataset, then `smoke.dataset verify --deep` → intact
- `alembic check` clean again after the round-trip

Plus:

- full unit suite across all five CI splits: **406 passed, 9 skipped**
- both architecture ratchets pass (`check_layer_imports`, `check_service_commits`)
- mypy reports nothing new; `models/activity.py` is clean
- `app.openapi()` **byte-identical** to `main` (15597 lines, empty diff) — no endpoint is touched

## Not in this PR

Steps 2–6, and the two open questions the later steps depend on: the production `count(*)` that sizes the backfill, and whether to widen `_build_deep`'s seeded verbs (2 of 15) before step 3 so the backfill test is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)