### PR TITLE
docs: make the README match the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ format:
 	bash scripts/format.sh
 
 check:
-	bash scripts/lint.sh
+	bash scripts/static_analysis/lint.sh
 	python scripts/check.py
 
 dev-run:
@@ -17,8 +17,3 @@ compile-email-templates:
 	mjml chafan_core/app/email-templates/src/verification_code.mjml -o chafan_core/app/email-templates/build/verification_code.html
 	mjml chafan_core/app/email-templates/src/notifications.mjml -o chafan_core/app/email-templates/build/notifications.html
 	mjml chafan_core/app/email-templates/src/feedback_status_update.mjml -o chafan_core/app/email-templates/build/feedback_status_update.html
-
-reset-and-run-unit-tests:
-	exit 1
-	bash scripts/reset_app_state.sh
-	bash scripts/run-unit-tests.sh

--- a/README.md
+++ b/README.md
@@ -17,24 +17,49 @@
 nix develop
 ```
 
-This drops you into a shell with Python and every backend dependency available. Run all subsequent commands from inside this shell.
+This drops you into a shell with Python and every backend dependency available.
+
+Run all subsequent commands **from the repository root**, inside this shell. Several tools depend on it: `alembic.ini` sets `script_location = alembic`, a relative path, so `alembic` outside the root fails with `No config file 'alembic.ini' found`. Set `PYTHONPATH` to the root as well, so that `chafan_core` is importable:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+export PYTHONPATH="$PWD"
+```
 
 ### Configure environment
 
-Create a `.env` (or export the variables in your shell) with at minimum:
+Settings are read from the environment; `.env` in the repository root is read too, and real environment variables win over it. See `chafan_core/app/config.py` for the full list of settings and their defaults.
+
+Only three have no default and must be set: `DATABASE_URL`, `REDIS_URL`, and `SERVER_HOST`.
+
+The quickest start is to copy `env.ci` — the configuration CI runs against, so it is known to work — and edit it:
+
+```bash
+cp env.ci .env
+```
+
+A minimal `.env` of your own:
 
 ```
-SERVER_NAME=dev.cha.fan
 SERVER_HOST=http://dev.cha.fan:4582
+DATABASE_URL=postgresql://<user>@localhost:5432/chafan_dev
+REDIS_URL=redis://127.0.0.1:6379
+SERVER_NAME=dev.cha.fan
 BACKEND_CORS_ORIGINS=["http://dev.cha.fan:8080"]
 PROJECT_NAME=Chafan Dev
 SECRET_KEY=change-me
 FIRST_SUPERUSER=admin@cha.fan
 FIRST_SUPERUSER_PASSWORD=change-me
 USERS_OPEN_REGISTRATION=False
-DATABASE_URL=postgresql://<user>@localhost:5432/chafan_dev
-REDIS_URL=redis://127.0.0.1:6379
 ENV=dev
+```
+
+### Point `dev.cha.fan` at your machine
+
+The dev server binds the hostname `dev.cha.fan`, which resolves publicly to an address you cannot bind locally. Add it to `/etc/hosts` first, or `make dev-run` fails with `Cannot assign requested address`:
+
+```
+127.0.0.1 dev.cha.fan
 ```
 
 ### Initialize the database
@@ -59,7 +84,7 @@ API docs: http://dev.cha.fan:4582/docs
    ```bash
    alembic revision --autogenerate -m "Add column last_name to User model"
    ```
-   See the [Alembic autogenerate docs](https://alembic.sqlalchemy.org/en/latest/autogenerate.html). **Always inspect the generated file** before applying.
+   See the [Alembic autogenerate docs](https://alembic.sqlalchemy.org/en/latest/autogenerate.html). **Always inspect the generated file** before applying. In particular, give constraints an explicit name — an unnamed one leaves the downgrade with no name to drop.
 3. Apply:
    ```bash
    alembic upgrade head
@@ -69,9 +94,11 @@ API docs: http://dev.cha.fan:4582/docs
    alembic downgrade <revision-id>
    ```
 
+The `Migrations` workflow tests migrations as a deliverable in their own right: exactly one head, a build from scratch, no drift between models and migrations (`alembic check`), and a downgrade/upgrade round-trip of the migrations the pull request adds, run against a populated database. See `.github/workflows/migrations.yml`.
+
 ## Tests
 
-Reset persistent state, then run:
+`scripts/reset_app_state.sh` gives you a clean slate. **It drops and recreates the `chafan_dev` database and flushes Redis** — everything in your dev database is lost. It connects as the `postgres` superuser on `localhost:5432`.
 
 ```bash
 bash scripts/reset_app_state.sh
@@ -84,19 +111,50 @@ A single file:
 pytest -vv chafan_core/tests/app/email/test_email.py
 ```
 
+The tests share one database and do not isolate themselves from each other, so a reset between full runs is the reliable way to run them. CI splits the suite across five jobs (search/feed/permission, two CRUD halves, API, email); see `.github/workflows/main-test.yml`.
+
+### End-to-end smoke suite
+
+`smoke/` is a separate suite that drives a live server over HTTP, in bootstrap mode: fresh database, migrate, seed fixtures, start uvicorn, run the suite.
+
+```bash
+bash scripts/e2e/run_e2e_smoke.sh
+```
+
+It expects the repository root as the working directory, Postgres and Redis up, the environment sourced, and the nix dev shell — the same preconditions CI sets up in `.github/workflows/e2e-smoke.yml`. `smoke/dataset` also defines the seeded dataset that the migrations workflow runs against.
+
+## Checks before a pull request
+
+```bash
+make format   # isort, autoflake, black
+make check    # architecture ratchets, mypy, black/isort/flake8, event-table consistency
+```
+
+`make check` runs `scripts/static_analysis/lint.sh` — the same script the `Static Analysis` workflow runs — plus `scripts/check.py`, which asserts that every event verb has a row in both `EVENT_TEMPLATES` and the distribution policy table. The two architecture ratchets (`check_layer_imports.py`, `check_service_commits.py`) must pass; the formatting and typing checks are advisory.
+
 ## How to add a new event type
+
 - Core backend
   - Add event definition: `chafan_core/app/schemas/event.py`
-  - If the event goes to the activity feed: update `chafan_core/app/feed.py:get_activity_receivers`
+  - Add a policy row for the verb: `chafan_core/app/services/activity_policy.py` (`POLICY`) — this is what decides whether the event is published as an `Activity`, which `Audience` receives it in the feed, and which audiences are notified. `chafan_core/app/services/events.py` resolves those audiences and is the single place an event reaches its sinks.
   - If the event goes to notifications:
     - `chafan_core/app/responders/event.py`: `materialize_event` (if a new field type)
     - `chafan_core/app/common.py`: `EVENT_TEMPLATES`
-- PWA
+- PWA ([chafan-dev/chafan-pwa](https://github.com/chafan-dev/chafan-pwa))
   - Add event definition: `src/interfaces/index.ts`
   - If the event goes to the activity feed: update event card in `src/views/main/Home.vue`
   - Update event field rendering: `src/components/Event.vue` (if a new field type)
   - Update event translation rendering: `src/main.ts`
 
+## Documentation
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — the prod-first principle: when prod code and the test suite disagree, prod is the spec.
+- [`docs/glossary.md`](docs/glossary.md) — event, activity, feed, notification, and the other vocabulary of this codebase.
+- [`docs/proposals/`](docs/proposals) — design documents, each with a status header:
+  - [Target Architecture](docs/proposals/2026-07-15-target-architecture.md) — the layering the codebase is moving to, and the import rule CI enforces.
+  - [Event distribution](docs/proposals/2026-08-03-event-distribution.md) — one seam for Activity, Feed and Notification.
+  - [Activity as the event log, Feed as a receiver index](docs/proposals/2026-08-04-activity-feed-reassignment.md)
+
 ## Copyright
 
-For all files within this repo, see `LICENSE` for default copyright unless otherwise declared in file:
+For all files within this repo, see `LICENSE` for the default copyright, unless a file declares otherwise.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 
-#from dotenv import load_dotenv  # isort:skip
-#load_dotenv()  # isort:skip
+# No load_dotenv() here: `Settings` reads `.env` itself (see
+# chafan_core/app/config.py), so importing it below is enough.
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool

--- a/chafan_core/app/config.py
+++ b/chafan_core/app/config.py
@@ -79,6 +79,19 @@ class Settings(BaseSettings):
 
     class Config:
         case_sensitive = True
+        # Read `.env` from the working directory, so that every entrypoint
+        # picks it up -- the app, alembic, the scripts. Before this, only the
+        # handful of scripts that call `load_dotenv()` themselves did, and
+        # `alembic upgrade head` (which does not) failed on a machine whose
+        # configuration lived entirely in `.env`. Real environment variables
+        # still win over the file.
+        env_file = ".env"
+        # A dotenv file is shell configuration, not just app configuration: it
+        # is also `source`d to set PGPASSWORD, PGOPTIONS and friends (see
+        # env.ci). Unlike real environment variables, keys read from the file
+        # are passed to the model as inputs, so without this an unrelated key
+        # in `.env` would fail startup with `extra_forbidden`.
+        extra = "ignore"
 
     ### Limit settings
     VISITORS_READ_ARTICLE_LIMIT: int = 100 #previous 5


### PR DESCRIPTION
Four README instructions are wrong rather than merely incomplete; following the Getting Started section in order on a fresh machine does not produce a running server.

## Fixed by changing code

**`.env` was never read.** The README's central setup step is "create a `.env`", but `Settings` declared no `env_file` and the `load_dotenv()` in `alembic/env.py` was commented out. Only `initial_data.py`, `check.py`, `simple_session.py` and `smoke/` called it themselves — so within the README's own two-line init block, `python scripts/initial_data.py` worked from `.env` and `alembic upgrade head` did not.

Rather than document the workaround, `Settings` now reads `.env`, and every entrypoint inherits it. Real environment variables still take precedence, so CI (which sources `env.ci`) is unaffected. `extra = "ignore"` comes with it: keys read from a dotenv file are passed to the model as inputs, unlike environment variables, so a `.env` copied from `env.ci` would otherwise fail startup on `PGPASSWORD`.

Verified with a `.env` present and `DATABASE_URL`/`REDIS_URL`/`SERVER_HOST` unset in the environment: importing the app and `alembic current` both previously failed with `Field required`, and now succeed (`7a670908f3fa (head)`). With the variable also exported, the exported value wins.

## Fixed by changing the README

- **alembic only works from the repository root** — `alembic.ini` sets a relative `script_location`, so running it from a subdirectory fails with `No config file 'alembic.ini' found`. The README showed a bare `alembic upgrade head` with no working directory and no `PYTHONPATH`. This is the failure that prompted the PR.
- **`make dev-run` binds `dev.cha.fan`**, which resolves publicly to a Cloudflare address; binding it locally returns `Cannot assign requested address`. It needs an `/etc/hosts` entry the README never mentioned.
- **The event-type recipe pointed at deleted code** — `chafan_core/app/feed.py:get_activity_receivers` went away in the feed redesign. Routing is now the `POLICY` table in `services/activity_policy.py`, resolved by `services/events.py`.

Newly documented, all previously absent: `env.ci` as the known-good configuration and the fact that only `DATABASE_URL`, `REDIS_URL` and `SERVER_HOST` have no default; that `reset_app_state.sh` drops the database and flushes Redis; the smoke suite; `make format` / `make check`; and `CONTRIBUTING.md`, the glossary and the proposals, none of which were linked from anywhere.

## Dead Makefile targets

- `reset-and-run-unit-tests` began with `exit 1` and called `scripts/run-unit-tests.sh`, which does not exist — removed.
- `check` called `scripts/lint.sh`, which moved to `scripts/static_analysis/lint.sh` — repointed. `make check` now runs to completion: both architecture ratchets pass and `scripts/check.py` reports 35 policy verbs.

## Not in scope

Badges are left alone deliberately — one workflow of five is advertised, but that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qFDkX2TFfbQrDLt5utnkx