### PR TITLE
alembic: put the repo root on sys.path

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -4,6 +4,12 @@
 # path to migration scripts
 script_location = alembic
 
+# Prepended to sys.path before env.py runs. Alembic loads env.py through its
+# own module loader, which does not put the working directory on sys.path, so
+# without this `from chafan_core.app.config import settings` fails with
+# ModuleNotFoundError unless the caller exports PYTHONPATH by hand.
+prepend_sys_path = .
+
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
 


### PR DESCRIPTION
`alembic upgrade head`, run from the repository root with the environment sourced, fails:

```
File "alembic/env.py", line 10, in <module>
    from chafan_core.app.config import settings
ModuleNotFoundError: No module named 'chafan_core'
```

Alembic loads `env.py` through its own module loader (`util.pyfiles.load_module_py`) rather than as a normal import, so the working directory never lands on `sys.path` the way it would for `python -m`. Every alembic invocation therefore needs `PYTHONPATH` exported by hand — which is why all of them in `.github/workflows/` are written `PYTHONPATH=$PWD alembic ...`, a workaround repeated at each call site instead of being stated once.

`prepend_sys_path` is alembic's own option for this, and ships in the default ini template that predates this repo's copy. Setting it to `.` makes the command work from the repository root — where `alembic.ini`'s relative `script_location` already requires it to be run from — with no `PYTHONPATH`.

The CI workflows keep their explicit `PYTHONPATH`: it is still needed for the pytest and script invocations around them, and setting it twice is harmless. The migrations workflow exercises this file on every PR, so CI here is the check that the option is spelled correctly.

Independent of #175 (README accuracy); no overlapping files.

Not verified locally — pushed for CI to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qFDkX2TFfbQrDLt5utnkx