### PR TITLE
activity: populate the subject column on write (step 4 item 1, step 2)

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -56,13 +56,22 @@ jobs:
         "
 
     - name: Run unit tests
+      # Everything directly under tests/app/, by subtraction rather than by
+      # name: the subdirectories below have their own steps, and anything else
+      # added there should run without also having to be listed here.
+      # test_activity_policy.py and test_events_distribute.py arrived in #167
+      # and had never run in CI, because this step named its files one by one.
       run: |
         set -a
         source env.ci
         set +a
         nix develop --command bash -c "
           set -e
-          PYTHONPATH=\$PWD pytest --cov=chafan_core/app --cov-report=xml:coverage-unit.xml chafan_core/tests/app/test_search.py chafan_core/tests/app/test_feed.py chafan_core/tests/app/test_user_permission.py -v
+          PYTHONPATH=\$PWD pytest --cov=chafan_core/app --cov-report=xml:coverage-unit.xml -v \
+            chafan_core/tests/app/ \
+            --ignore=chafan_core/tests/app/api \
+            --ignore=chafan_core/tests/app/crud \
+            --ignore=chafan_core/tests/app/email
         "
 
     - name: Upload coverage

--- a/chafan_core/app/services/events.py
+++ b/chafan_core/app/services/events.py
@@ -127,6 +127,25 @@ def _comment_of(ctx: RequestContext, c: object) -> Optional[models.Comment]:
     return crud.comment.get(db, id=cid) if cid is not None else None
 
 
+def _subject_user_of(ctx: RequestContext, c: object) -> Optional[models.User]:
+    """The user the event is *about*, or None if it cannot be resolved.
+
+    One derivation for two sinks: ``Activity.subject_user_id`` and
+    ``Feed.subject_user_uuid`` are the same fact, and resolving it twice is how
+    they would drift apart.
+
+    None is a real answer, not an error. A content model with no ``subject_id``
+    yields None, and so does a ``subject_id`` naming a user that no longer
+    exists -- an event that has already happened must still be recorded, so both
+    columns are nullable rather than the write failing. See
+    docs/proposals/2026-08-04-activity-feed-reassignment.md, "Why nullable".
+    """
+    subject_id = _attr(c, "subject_id")
+    if subject_id is None:
+        return None
+    return crud.user.get(ctx.get_db(), id=subject_id)
+
+
 # --------------------------------------------------------------------------
 # Site derivation. Reproduces the site_id each call site passed by hand.
 # --------------------------------------------------------------------------
@@ -164,10 +183,7 @@ def _site_id_of(ctx: RequestContext, c: object) -> Optional[int]:
 
 
 def _subject_followers(ctx: RequestContext, c: object) -> Set[int]:
-    subject_id = _attr(c, "subject_id")
-    if subject_id is None:
-        return set()
-    subject = crud.user.get(ctx.get_db(), id=subject_id)
+    subject = _subject_user_of(ctx, c)
     if subject is None:
         return set()
     return {follower.id for follower in subject.followers}
@@ -358,22 +374,24 @@ def _activity_precondition(ctx: RequestContext, c: object) -> bool:
 
 
 def deliver(
-    ctx: RequestContext, activity: models.Activity, receiver_ids: Set[int]
+    ctx: RequestContext,
+    activity: models.Activity,
+    receiver_ids: Set[int],
+    *,
+    subject: Optional[models.User],
 ) -> None:
     """Write one Feed row per receiver.
 
     The single place fan-out happens, so that swapping fan-out-on-write for a
     read-time join stays a change to one function.
+
+    ``subject`` is passed in rather than re-derived from ``activity.event_json``
+    because :func:`distribute` has already resolved it for the Activity column.
+    It is required and may be None -- see :func:`_subject_user_of`.
     """
     assert activity.id is not None
     db = ctx.get_db()
-    subject_user_uuid = None
-    event = EventInternal.parse_raw(activity.event_json)
-    subject_id = _attr(event.content, "subject_id")
-    if subject_id is not None:
-        subject = crud.user.get(db, id=subject_id)
-        if subject is not None:
-            subject_user_uuid = subject.uuid
+    subject_user_uuid = subject.uuid if subject is not None else None
     for receiver_id in receiver_ids:
         existing = (
             db.query(models.Feed)
@@ -450,16 +468,19 @@ def distribute(
         return None
 
     activity: Optional[models.Activity] = None
+    subject: Optional[models.User] = None
     if (
         Sink.ACTIVITY in sinks
         and policy.writes_activity
         and _activity_precondition(ctx, content)
     ):
         db = ctx.get_db()
+        subject = _subject_user_of(ctx, content)
         activity = models.Activity(
             created_at=event.created_at,
             site_id=_site_id_of(ctx, content),
             event_json=event.json(),
+            subject_user_id=subject.id if subject is not None else None,
         )
         db.add(activity)
         db.flush()
@@ -468,7 +489,7 @@ def distribute(
         feed_receivers: Set[int] = set()
         for audience in policy.feed_audience:
             feed_receivers |= _resolve(ctx, audience, content)
-        deliver(ctx, activity, feed_receivers)
+        deliver(ctx, activity, feed_receivers, subject=subject)
 
     if Sink.NOTIFICATION in sinks and policy.notifies:
         notify_receivers: Set[int] = set()

--- a/chafan_core/tests/app/test_events_distribute.py
+++ b/chafan_core/tests/app/test_events_distribute.py
@@ -10,6 +10,7 @@ import datetime
 from typing import Set
 
 import pytest
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from chafan_core.app.infra.request_context import RequestContext
@@ -125,6 +126,63 @@ def test_create_question_writes_activity_with_site_and_fans_out(ctx) -> None:
     feeds = db.query(models.Feed).filter_by(activity_id=activity.id).all()
     assert {f.receiver_id for f in feeds} == {follower.id}
     assert _activities_for(db, "create_question", max_id)
+
+
+def test_activity_and_feed_agree_on_the_subject(ctx: RequestContext) -> None:
+    """One derivation, two sinks: the Activity column and the Feed column.
+
+    Activity.subject_user_id is what step 4 will query subject timelines by, so
+    it has to name the same user Feed.subject_user_uuid has always named.
+    """
+    db = ctx.get_db()
+    author = _user(db)
+    follower = _user(db)
+    author.followers.append(follower)
+    site = _site(db, moderator=author)
+    question = _question(db, author_id=author.id, site=site)
+    db.flush()
+
+    activity = events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=CreateQuestionInternal(
+                subject_id=author.id, question_id=question.id
+            ),
+        ),
+    )
+
+    assert activity is not None
+    assert activity.subject_user_id == author.id
+    db.flush()
+    feeds = db.query(models.Feed).filter_by(activity_id=activity.id).all()
+    assert [f.subject_user_uuid for f in feeds] == [author.uuid]
+
+
+def test_vanished_subject_writes_null_not_an_error(ctx: RequestContext) -> None:
+    """The containment behind the nullable column.
+
+    An event that has already happened must still be recorded. A subject_id
+    naming a user that is gone resolves to None and the row is written with a
+    null subject -- rather than a foreign key violation taking down the
+    caller's transaction along with it.
+    """
+    db = ctx.get_db()
+    followed = _user(db)
+    db.flush()
+    missing_id = (db.query(func.max(models.User.id)).scalar() or 0) + 1
+
+    activity = events.distribute(
+        ctx,
+        EventInternal(
+            created_at=_now(),
+            content=FollowUserInternal(subject_id=missing_id, user_id=followed.id),
+        ),
+        sinks=frozenset({events.Sink.ACTIVITY}),
+    )
+
+    assert activity is not None, "the event happened; it must still be recorded"
+    assert activity.subject_user_id is None
 
 
 def test_no_notification_for_create_question(ctx) -> None:

--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -1,6 +1,6 @@
 # Activity as the event log, Feed as a receiver index
 
-**Status:** proposed | **Date:** 2026-08-04 | **Last reviewed:** 2026-08-05
+**Status:** proposed | **Date:** 2026-08-04 | **Last reviewed:** 2026-08-06
 
 Step 4, item 1 of the activity/feed work. Steps 1–3 landed in #166, #167, #168
 and #169; the seam they built (`services/events.py`) is what makes this
@@ -151,18 +151,29 @@ this work.
 Each is independently deployable and independently revertible. Steps 1–3 change
 no behavior at all.
 
-**1. Add the column. — done, `7a670908f3fa`.** Migration adding
+**1. Add the column. — done, `7a670908f3fa`, applied to production 2026-08-06.**
+Migration adding
 `activity.subject_user_id`, nullable,
 indexed, FK to `user.id`. Nothing reads or writes it yet. Covered by the
 migrations CI (#171, extended in #173): one head, builds from scratch, no
 model/migration drift, and a downgrade/upgrade round-trip across a *populated*
 database with the seeded rows verified afterwards.
 
-**2. Populate it on write.** `events.distribute` already derives the subject —
-`deliver()` resolves `subject_id` from the event content to set
-`Feed.subject_user_uuid`. The same derivation sets the new column when the
-`Activity` is constructed. New rows are complete from here on; old rows are
-still null.
+**2. Populate it on write. — done, #178.** `events.distribute` already derived the
+subject — `deliver()` resolved `subject_id` from the event content to set
+`Feed.subject_user_uuid`. That derivation is now `events._subject_user_of`,
+called once when the `Activity` is constructed and passed to `deliver`, so the
+two columns cannot disagree: one lookup answers both. New rows are complete
+from here on; old rows are still null.
+
+Two tests pin it: `Activity.subject_user_id` and `Feed.subject_user_uuid` name
+the same user, and a `subject_id` whose user no longer exists writes a null
+rather than raising a foreign key violation into the caller's transaction.
+
+Both live in `test_events_distribute.py`, which — along with
+`test_activity_policy.py` — had never run in CI: the unit-tests job named its
+files one by one and was last touched in #155, before #167 added them. That
+step now takes everything directly under `tests/app/`, by subtraction.
 
 **3. Backfill.** Parse `event_json` for every row where `subject_user_id IS
 NULL`, extract `subject_id`, write it. Batched and idempotent, so it can be run,
@@ -253,7 +264,8 @@ Three tests the change should carry:
   the query. Pins the safety property above.
 - An `Activity` whose payload has no resolvable subject is **skipped, not
   fatal** — it backfills to null, writes to null, and is absent from subject
-  queries. Pins the containment described under "Why nullable".
+  queries. Pins the containment described under "Why nullable". The *writes to
+  null* half landed with step 2; the other two halves belong to steps 3 and 4.
 
 ## Open questions
 


### PR DESCRIPTION
Step 2 of [`docs/proposals/2026-08-04-activity-feed-reassignment.md`](https://github.com/chafan-dev/chafan-core/blob/main/docs/proposals/2026-08-04-activity-feed-reassignment.md), on top of the column #174 added. That migration (`7a670908f3fa`) was applied to production today.

Nothing reads `subject_user_id` yet — step 3 backfills the historical rows, step 4 switches the subject timeline onto it. **No behavior change.**

## One derivation, two sinks

`distribute` already derived the subject: `deliver()` parsed `activity.event_json` back into an `EventInternal` to resolve `subject_id` and set `Feed.subject_user_uuid`. That derivation is now `events._subject_user_of`, called once when the `Activity` is constructed. The Activity gets the id, `deliver` gets the `User`, and neither can disagree with the other because there is only one lookup. The re-parse goes away with it, and `_subject_followers` — which resolved the same user a third time — now shares it too.

`subject` is a **required** keyword argument on `deliver` rather than something it re-derives or reads back off the `Activity`: it may legitimately be `None`, and a default would let a future caller silently write a null Feed subject.

## None stays a real answer

An event that has already happened must still be recorded. A `subject_id` naming a user that no longer exists writes a null rather than raising a foreign key violation into the caller's transaction — the same containment as the audience resolvers in #168, and the reason the column is nullable.

Two tests pin this: `Activity.subject_user_id` and `Feed.subject_user_uuid` name the same user, and a vanished subject yields a null-subject `Activity` rather than an `IntegrityError`.

## The CI gap this turned up

Both tests live in `test_events_distribute.py`, **which had never run in CI.** The unit-tests job listed its three test files by name and was last touched in #155; #167 added `test_events_distribute.py` and `test_activity_policy.py` next to them, and nothing picked them up.

That step now takes everything directly under `tests/app/` by subtraction, so the subdirectories keep their own steps and anything added at the top level runs without also having to be listed. Net effect: **18 existing tests that were dead in CI** start running, plus the 2 added here.

## Verification

- Full unit suite across all five CI splits: **426 passed, 9 skipped** — up from 406 by exactly those 20 tests.
- Both architecture ratchets pass.
- `app.openapi()` byte-identical to `main`.
- mypy: one error **better** than main (the removed `parse_raw` on a `Column[str]`), none added.
- Migrations job reproduced locally against a database built from scratch: `alembic check` clean, `smoke.dataset build --deep` then `verify --deep` intact, and every `Activity` the seed writes now carries a `subject_user_id` that agrees with its `Feed` row.

## Not in this PR

Step 3's backfill still needs `SELECT count(*) FROM activity` against production to decide between one statement and a batched script. Worth noting the seed only exercises 2 of the 15 activity-writing verbs — the proposal's open question about widening `_build_deep` before step 3 is still open, and matters more once a backfill is the thing being tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)