### PR TITLE
feed: replace the auto-fill with a thin, bounded component

### DIFF
--- a/chafan_core/app/api/api_v1/endpoints/activities.py
+++ b/chafan_core/app/api/api_v1/endpoints/activities.py
@@ -74,6 +74,9 @@ def get_settings(
     return ctx.get_current_active_user().feed_settings
 
 
+# TODO: these two endpoints read and write a setting the feed no longer honors
+# -- see the blocked_origins note in services/feed_impl.get_activities_v2. They
+# are left in place so existing settings are not lost while that is decided.
 @router.put("/settings/blocked-origins/", response_model=schemas.GenericResponse)
 def update_blocked_origins(
     ctx: RequestContext = Depends(deps.get_request_context_logged_in),

--- a/chafan_core/app/services/feed.py
+++ b/chafan_core/app/services/feed.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import List, Optional
 
 from chafan_core.app import schemas
-from chafan_core.app.services.feed_impl import get_activities_v2, get_random_activities
-
-import logging
+from chafan_core.app.services import feed_fill
+from chafan_core.app.services.feed_impl import get_activities_v2
 
 logger = logging.getLogger(__name__)
 
@@ -30,17 +30,17 @@ def get_user_activity(
         subject_user_uuid=subject_user_uuid,
     )
 
-    insufficient = limit - len(activities)
-    tolerate_order = before_activity_id is None
-    if random:
-        tolerate_order = True
+    if subject_user_uuid is not None:
+        # A profile timeline is a record of what one user did. Padding it with
+        # somebody else's activity would make it say something untrue, so a
+        # short one stays short.
+        return activities
 
-    if tolerate_order and insufficient > 0 and subject_user_uuid is None:
-        extra_activities = get_random_activities(
-            receiver_user_id=current_user_id,
-            before_activity_id=before_activity_id,
-            limit=limit,
-        )
-        activities.extend(extra_activities)
-
-    return activities
+    return feed_fill.top_up(
+        ctx,
+        activities,
+        receiver_id=current_user_id,
+        limit=limit,
+        before_activity_id=before_activity_id,
+        random=random,
+    )

--- a/chafan_core/app/services/feed_fill.py
+++ b/chafan_core/app/services/feed_fill.py
@@ -1,0 +1,132 @@
+"""Padding for a feed that came up nearly empty.
+
+A new user follows nobody, so their feed has nothing in it and the home page
+renders blank. This module puts *something* there. That is its entire job.
+
+Deliberately a placeholder
+--------------------------
+There is no ranking here, no personalization, no notion of what is worth
+reading -- just the most recent publicly-readable activity. Choosing good
+content is a real design problem and is not attempted yet. When it is, this
+module is the one thing that changes: everything else knows only
+:func:`top_up`.
+
+Best-effort, and bounded
+------------------------
+It looks at a fixed window of recent activity and returns what passes. Coming
+back with fewer than asked -- or with nothing -- is a correct outcome, not a
+failure to retry harder. That is what lets the query stay bounded, and bounded
+is the point: the version this replaces queried the whole ``activity`` table
+with no ``LIMIT`` and materialized rows until it had enough, so its cost grew
+with the table on every under-filled request.
+
+It also dropped the ``activity.id % 10 != receiver_id % 10`` filter that
+version used. That was never randomizing anything -- it is deterministic, so a
+user saw identical padding on every request and any two users in the same
+bucket saw identical padding as each other. It only cost an unindexable scan.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Set
+
+from chafan_core.app import models, schemas
+from chafan_core.app.infra.request_context import RequestContext
+from chafan_core.app.services.activity_policy import ALWAYS_PUBLIC_EVENT_VERBS
+from chafan_core.app.services.feed_impl import materialize_activity
+
+logger = logging.getLogger(__name__)
+
+# Below this many real activities the page reads as empty and is worth padding.
+# A guess, and the number to revisit when content quality gets designed. The
+# version this replaces padded whenever the page was not completely full, so a
+# user one item short of a full page triggered the whole scan described above.
+FILL_BELOW = 5
+
+# How far back to look. Caps both the query and the number of materializations,
+# each of which costs several more queries. Padding that comes up short is
+# fine; padding that walks the table is not.
+SCAN_LIMIT = 200
+
+
+def _is_public(activity: schemas.Activity) -> bool:
+    """Whether this activity may be shown to someone with no connection to it.
+
+    The per-viewer permission gate in ``materialize_activity`` has already run
+    by the time this is called; this is the *additional* restriction that
+    padding is public content only. A viewer's own private-site activity
+    reaches them through the feed, never through padding.
+    """
+    if activity.site and activity.site.public_readable:
+        return True
+    return activity.event.content.verb in ALWAYS_PUBLIC_EVENT_VERBS
+
+
+def _recent_public(
+    ctx: RequestContext,
+    *,
+    receiver_id: int,
+    count: int,
+    exclude_activity_ids: Set[int],
+    before_activity_id: Optional[int],
+) -> List[schemas.Activity]:
+    db = ctx.get_db()
+    query = db.query(models.Activity)
+    if before_activity_id is not None:
+        query = query.filter(models.Activity.id < before_activity_id)
+    recent = query.order_by(models.Activity.id.desc()).limit(SCAN_LIMIT).all()
+
+    padding: List[schemas.Activity] = []
+    for activity in recent:
+        if activity.id in exclude_activity_ids:
+            continue
+        materialized = materialize_activity(ctx, activity, receiver_id, None)
+        if materialized is None or not _is_public(materialized):
+            continue
+        padding.append(materialized)
+        if len(padding) >= count:
+            break
+    return padding
+
+
+def top_up(
+    ctx: RequestContext,
+    activities: List[schemas.Activity],
+    *,
+    receiver_id: int,
+    limit: int,
+    before_activity_id: Optional[int],
+    random: bool,
+) -> List[schemas.Activity]:
+    """``activities``, padded with recent public activity if it is nearly empty.
+
+    Never returns more than ``limit`` items, and never repeats an activity that
+    is already in ``activities`` -- the version this replaces did both, because
+    it asked for a full ``limit`` of padding regardless of how many real
+    activities it already had and appended without checking for overlap.
+    """
+    if before_activity_id is not None and not random:
+        # Later pages are not padded: the reader has already seen the top of
+        # the feed, so a blank page there means the end of it.
+        return activities
+    if len(activities) >= FILL_BELOW:
+        return activities
+    shortfall = limit - len(activities)
+    if shortfall <= 0:
+        return activities
+
+    padding = _recent_public(
+        ctx,
+        receiver_id=receiver_id,
+        count=shortfall,
+        exclude_activity_ids={a.id for a in activities},
+        before_activity_id=before_activity_id,
+    )
+    logger.info(
+        "padded a %d-item feed for user %s with %d recent public activities",
+        len(activities),
+        receiver_id,
+        len(padding),
+    )
+    return activities + padding

--- a/chafan_core/app/services/feed_impl.py
+++ b/chafan_core/app/services/feed_impl.py
@@ -11,7 +11,6 @@ from chafan_core.app.schemas.event import (
     CreateQuestionInternal,
     EventInternal,
 )
-from chafan_core.app.services.activity_policy import ALWAYS_PUBLIC_EVENT_VERBS
 from chafan_core.app.infra.runtime import execute_with_broker
 from chafan_core.utils.base import map_, unwrap
 
@@ -139,7 +138,16 @@ def get_activities_v2(
     db = ctx.get_db()
     receiver = crud.user.get(db, id=receiver_user_id)
     assert receiver is not None
-    # TODO feed_settings not supported yet
+    # TODO: honor receiver.feed_settings.blocked_origins here. `is_blocked` and
+    # the two /activities/settings endpoints are still live, so a user can mute
+    # a site, see the setting persist, and keep seeing that site -- this branch
+    # is where that promise is dropped. The now-dead v1 `get_activities` below
+    # shows the three lines it takes. Not switched on blind: anyone holding a
+    # mute from before the v2 rewrite would silently lose feed content on
+    # deploy, so size it first with
+    #   SELECT count(*) FROM "user" WHERE feed_settings IS NOT NULL
+    #     AND feed_settings::jsonb -> 'blocked_origins' <> '[]'::jsonb;
+    # and decide between restoring the feature and deleting it.
     feeds = db.query(models.Feed)
     if subject_user_uuid is not None:
         feeds = feeds.filter_by(subject_user_uuid=subject_user_uuid)
@@ -151,7 +159,7 @@ def get_activities_v2(
     activities = []
     activity_ids = set()
     for feed in feeds:
-        feed_settings = None # TODO not supported yed
+        feed_settings = None  # TODO: see the blocked_origins note above.
         if feed.activity_id in activity_ids:
             continue
         activity = materialize_activity(
@@ -204,46 +212,6 @@ def get_activities( # TODO to remove this function
         return data
     else:
         return []
-
-
-def _is_public_activity(activity: schemas.Activity) -> bool:
-    if activity.site and activity.site.public_readable:
-        return True
-    return activity.event.content.verb in ALWAYS_PUBLIC_EVENT_VERBS
-
-
-def get_random_activities(
-    *, receiver_user_id: int, before_activity_id: Optional[int], limit: int
-) -> List[schemas.Activity]:
-    id_bucket = receiver_user_id % 10
-
-    def runnable(broker: RequestContext) -> List[schemas.Activity]:
-        db = broker.get_db()
-        stream = db.query(models.Activity)
-        if before_activity_id is not None:
-            stream = stream.filter(models.Activity.id < before_activity_id)
-        stream = stream.filter(models.Activity.id % 10 != id_bucket).order_by(
-            models.Activity.id.desc()
-        )
-        activities: List[schemas.Activity] = []
-        for activity in stream:
-            materialized_activity = materialize_activity(
-                broker, activity, receiver_user_id, None
-            )
-            if len(activities) >= limit:
-                break
-            if materialized_activity and _is_public_activity(materialized_activity):
-                activities.append(materialized_activity)
-        return activities
-
-    data = execute_with_broker(runnable)
-    if data:
-        return data
-    else:
-        return []
-
-
-CACHE_REWIND_SIZE = 1000
 
 
 

--- a/chafan_core/tests/app/test_feed.py
+++ b/chafan_core/tests/app/test_feed.py
@@ -1,7 +1,202 @@
+"""Feed padding: when it happens, and what it is not allowed to do.
 
-# from chafan_core.app.feed import new_activity_into_feed, ActivityType
-# TODO feed.py is dependent on curd, making it hard to run in a unit test 2025-07-19
-def test_activity_to_feed():
-    a = 1
+The padding exists so a user who follows nobody does not see a blank home
+page. These pin the boundaries the version in #85 had and the rewrite of it
+lost -- it padded any page that was not completely full, could return more
+items than the caller asked for, and could repeat an activity that was already
+in the feed.
+"""
+
+import datetime
+from typing import List, Optional
+
+import pytest
+from sqlalchemy.orm import Session
+
+from chafan_core.app import crud, models, schemas
+from chafan_core.app.infra.request_context import RequestContext
+from chafan_core.app.schemas.event import CreateQuestionInternal, EventInternal
+from chafan_core.app.schemas.question import QuestionCreate
+from chafan_core.app.schemas.site import SiteCreate
+from chafan_core.app.schemas.user import UserCreate
+from chafan_core.app.services import events, feed as feed_service, feed_fill
+from chafan_core.tests.utils.utils import (
+    random_email,
+    random_password,
+    random_short_lower_string,
+)
 
 
+@pytest.fixture
+def ctx(db: Session):
+    """A RequestContext sharing the suite's session.
+
+    Same reasoning as test_events_distribute: a fresh one would open a second
+    transaction and block on rows this one holds.
+    """
+    context = RequestContext()
+    context.db = db
+    yield context
+
+
+def _user(db: Session):
+    return crud.user.create(
+        db,
+        obj_in=UserCreate(
+            email=random_email(),
+            password=random_password(),
+            handle=random_short_lower_string(),
+        ),
+    )
+
+
+def _public_site(db: Session, moderator):
+    return crud.site.create_with_permission_type(
+        db,
+        obj_in=SiteCreate(
+            name=f"S {random_short_lower_string()}",
+            subdomain=random_short_lower_string(),
+            description="d",
+            permission_type="public",
+        ),
+        moderator=moderator,
+        category_topic_id=None,
+    )
+
+
+def _ask(ctx: RequestContext, author, site):
+    """A question plus the Activity and Feed rows its creation distributes."""
+    db = ctx.get_db()
+    question = crud.question.create_with_author(
+        db,
+        obj_in=QuestionCreate(
+            site_uuid=site.uuid, title=f"Q {random_short_lower_string()}"
+        ),
+        author_id=author.id,
+    )
+    db.flush()
+    events.distribute(
+        ctx,
+        EventInternal(
+            created_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            content=CreateQuestionInternal(
+                subject_id=author.id, question_id=question.id
+            ),
+        ),
+    )
+    db.flush()
+    return question
+
+
+def _feed(
+    ctx: RequestContext,
+    user,
+    *,
+    limit: int = 20,
+    before_activity_id: Optional[int] = None,
+    random: bool = False,
+    subject_user_uuid: Optional[str] = None,
+) -> List[schemas.Activity]:
+    return feed_service.get_user_activity(
+        ctx,
+        current_user_id=user.id,
+        before_activity_id=before_activity_id,
+        limit=limit,
+        random=random,
+        subject_user_uuid=subject_user_uuid,
+    )
+
+
+def test_empty_feed_is_padded(ctx: RequestContext) -> None:
+    """The point of the feature: follow nobody, still see a page."""
+    db = ctx.get_db()
+    author = _user(db)
+    site = _public_site(db, moderator=author)
+    _ask(ctx, author, site)
+
+    # The newcomer follows nobody, so they have no Feed rows at all.
+    newcomer = _user(db)
+    db.flush()
+    assert db.query(models.Feed).filter_by(receiver_id=newcomer.id).count() == 0
+
+    activities = _feed(ctx, newcomer)
+
+    assert activities, "a user with no audience must still get a page"
+
+
+def test_padding_never_exceeds_the_requested_limit(ctx: RequestContext) -> None:
+    """The old caller asked for a full `limit` of padding on top of the feed."""
+    db = ctx.get_db()
+    author = _user(db)
+    site = _public_site(db, moderator=author)
+    for _ in range(3):
+        _ask(ctx, author, site)
+    newcomer = _user(db)
+    db.flush()
+
+    activities = _feed(ctx, newcomer, limit=2)
+
+    assert len(activities) <= 2
+
+
+def test_padding_does_not_repeat_the_feed(ctx: RequestContext) -> None:
+    """The old caller extended without checking for overlap."""
+    db = ctx.get_db()
+    author = _user(db)
+    follower = _user(db)
+    author.followers.append(follower)
+    site = _public_site(db, moderator=author)
+    _ask(ctx, author, site)
+    db.flush()
+
+    activities = _feed(ctx, follower)
+
+    ids = [a.id for a in activities]
+    assert len(ids) == len(set(ids)), "an activity must not appear twice"
+
+
+def test_a_full_feed_is_not_padded(ctx: RequestContext) -> None:
+    """Padding is for an empty page, not for one item short of a full one."""
+    db = ctx.get_db()
+    author = _user(db)
+    follower = _user(db)
+    author.followers.append(follower)
+    site = _public_site(db, moderator=author)
+    for _ in range(feed_fill.FILL_BELOW):
+        _ask(ctx, author, site)
+    db.flush()
+
+    activities = _feed(ctx, follower, limit=20)
+
+    assert len(activities) == feed_fill.FILL_BELOW, (
+        "a feed at or above the threshold is returned as-is, "
+        "even though the page is not full"
+    )
+
+
+def test_later_pages_are_not_padded(ctx: RequestContext) -> None:
+    """A blank second page means the end of the feed, not a page to fill."""
+    db = ctx.get_db()
+    author = _user(db)
+    site = _public_site(db, moderator=author)
+    _ask(ctx, author, site)
+    newcomer = _user(db)
+    db.flush()
+
+    activities = _feed(ctx, newcomer, before_activity_id=1)
+
+    assert activities == []
+
+
+def test_subject_timelines_are_never_padded(ctx: RequestContext) -> None:
+    """A profile must not claim its subject did something they did not."""
+    db = ctx.get_db()
+    author = _user(db)
+    site = _public_site(db, moderator=author)
+    _ask(ctx, author, site)
+    silent = _user(db)
+    db.flush()
+
+    activities = _feed(ctx, author, subject_user_uuid=silent.uuid)
+
+    assert activities == [], "a silent user's profile stays empty"


### PR DESCRIPTION
A user who follows nobody has an empty feed, so the home page renders blank. Padding it is the right idea; the implementation had drifted a long way from it. This replaces `get_random_activities` and its caller with one small module — `services/feed_fill.py` — that does only that job.

Independent of #178; branched from `main`.

## What it had become

The original is #85, *"用户的 Feed 内容过少时，会用关注的圈子内动态填充"*. There it fired **only when the feed was completely empty**, **replaced** the result rather than extending it, and set `random=True` on the response so the client knew it was looking at filler. The move into `services/` kept the function and lost all three properties. What was left:

- fired whenever the page was **not completely full** — one item short of 20 triggered the whole thing;
- queried the **entire `activity` table with no `LIMIT`** (SQLAlchemy buffers the full ORM result set) and materialized rows one at a time until it had enough, so cost grew with the table on every under-filled request;
- filtered `activity.id % 10 != receiver_id % 10`, which is unindexable and **randomizes nothing** — it's deterministic, so a user saw identical padding on every request, and two users in the same bucket saw identical padding as each other;
- asked for a full `limit` of padding regardless of how many real activities it already had, so **a request for 20 could return 39**;
- appended without checking overlap, so **an activity in the feed could appear twice**;
- ran through `execute_with_broker`, which opens a **second `RequestContext` and session** inside a request that already has one, auto-commits it, and turns any exception into `[]`.

## What replaces it

`feed_fill.top_up` fixes each of those and is deliberately dumb about content: most recent publicly-readable activity, nothing else. Choosing what is *worth reading* is a real design problem and is not attempted here — the module is written so that when it is, **this is the only file that changes**.

Bounded is the design point. It looks at a fixed window (`SCAN_LIMIT`) and returns what passes, so coming back short is a correct outcome rather than a reason to keep scanning. `FILL_BELOW` restores the "nearly empty" trigger as a named number to revisit.

Subject timelines are never padded — now stated in `services/feed.py` where the request shape is known. A profile is a record of what one user did; padding would make it say something untrue.

**Not restored:** the `random=True` response flag. `FeedSequence.random` exists but is currently just the echoed request parameter, so the frontend cannot tell feed from padding. Setting it correctly is a visible change for the PWA and belongs with the content-quality work, not with this refactor.

## `blocked_origins` — marked TODO, not fixed

`get_activities_v2` hardcodes `feed_settings = None`, so `is_blocked` never runs, while both `/activities/settings` endpoints still read and write the setting. A user can mute a site, see the setting persist, and keep seeing that site.

Wiring it up is ~3 lines (the dead v1 shows how), but switching it on is a **silent behavior change** for anyone holding a mute from before the v2 rewrite — their feed would quietly lose content on deploy. The note carries the query that sizes it and the two ways out (restore vs. delete).

## Tests

`test_feed.py` was a stub that asserted `a = 1`. It now pins the six boundaries above against real rows: empty feed is padded, padding never exceeds `limit`, padding never repeats the feed, a feed at the threshold is not padded, later pages are not padded, subject timelines are not padded.

## Verification

- All five CI splits: **411 passed, 9 skipped** — up from main's 406 by the 5 tests `test_feed.py` gains. (Locally I also widened split 1 to include `test_events_distribute.py` and `test_activity_policy.py`, which CI doesn't run until #178 lands: 429 passed, 9 skipped.)
- Both architecture ratchets pass.
- `app.openapi()` byte-identical to main.
- mypy reports nothing new for app code — `feed_fill.py` adds no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)