### PR TITLE
feed: delete the dead v1 get_activities (step 4 item 1, step 5)

### DIFF
--- a/chafan_core/app/services/feed_impl.py
+++ b/chafan_core/app/services/feed_impl.py
@@ -1,4 +1,3 @@
-from chafan_core.app.infra.request_context import RequestContext
 from typing import List, Optional
 
 from chafan_core.db.base_class import Base as BaseCrudModel
@@ -11,7 +10,6 @@ from chafan_core.app.schemas.event import (
     CreateQuestionInternal,
     EventInternal,
 )
-from chafan_core.app.infra.runtime import execute_with_broker
 from chafan_core.utils.base import map_, unwrap
 
 import logging
@@ -141,10 +139,11 @@ def get_activities_v2(
     # TODO: honor receiver.feed_settings.blocked_origins here. `is_blocked` and
     # the two /activities/settings endpoints are still live, so a user can mute
     # a site, see the setting persist, and keep seeing that site -- this branch
-    # is where that promise is dropped. The now-dead v1 `get_activities` below
-    # shows the three lines it takes. Not switched on blind: anyone holding a
-    # mute from before the v2 rewrite would silently lose feed content on
-    # deploy, so size it first with
+    # is where that promise is dropped. It takes three lines -- parse
+    # receiver.feed_settings into a UserFeedSettings and pass it to
+    # materialize_activity instead of None. Not switched on blind: anyone
+    # holding a mute from before the v2 rewrite would silently lose feed
+    # content on deploy, so size it first with
     #   SELECT count(*) FROM "user" WHERE feed_settings IS NOT NULL
     #     AND feed_settings::jsonb -> 'blocked_origins' <> '[]'::jsonb;
     # and decide between restoring the feature and deleting it.
@@ -172,46 +171,3 @@ def get_activities_v2(
             break
     logger.info("v2 get " + str(len(activities)))
     return activities
-
-
-def get_activities( # TODO to remove this function
-    *,
-    before_activity_id: Optional[int],
-    limit: int,
-    receiver_user_id: int,
-    subject_user_uuid: Optional[str],
-) -> List[schemas.Activity]:
-    def runnable(broker: RequestContext) -> List[schemas.Activity]:
-        db = broker.get_db()
-        receiver = crud.user.get(db, id=receiver_user_id)
-        assert receiver is not None, receiver_user_id
-        if receiver.uuid == subject_user_uuid:
-            receiver_id = crud.user.get_superuser(db).id
-        else:
-            receiver_id = receiver_user_id
-        feed_settings = None
-        if receiver.feed_settings:
-            feed_settings = UserFeedSettings.parse_obj(receiver.feed_settings)
-        activities = []
-        feeds = db.query(models.Feed).filter_by(receiver_id=receiver_id)
-        if before_activity_id:
-            feeds = feeds.filter(models.Feed.activity_id < before_activity_id)
-        if subject_user_uuid:
-            feeds = feeds.filter_by(subject_user_uuid=subject_user_uuid)
-        feeds = feeds.order_by(models.Feed.activity_id.desc()).limit(limit)
-        for feed in feeds:
-            activity = materialize_activity(
-                broker, feed.activity, receiver_user_id, feed_settings
-            )
-            if activity:
-                activities.append(activity)
-        return activities
-
-    data = execute_with_broker(runnable)
-    if data:
-        return data
-    else:
-        return []
-
-
-


### PR DESCRIPTION
Step 5 of [`docs/proposals/2026-08-04-activity-feed-reassignment.md`](https://github.com/chafan-dev/chafan-core/blob/main/docs/proposals/2026-08-04-activity-feed-reassignment.md). No behavior change — the function has had no callers since the v2 read path took over, and has carried `# TODO to remove this function` since then. Same category as `new_activity_into_feed`, which #169 deleted.

## What goes with it

The clearest statement of the defect the whole proposal is about:

```python
if receiver.uuid == subject_user_uuid:
    receiver_id = crud.user.get_superuser(db).id
```

Viewing your own profile swapped in the **superuser's** receiver id — because you do not follow yourself, so you have no `Feed` rows for your own activity, so your own profile would otherwise be blank. That workaround exists only because the subject timeline is served out of the delivery table. Step 4 removes the *need* for it rather than the workaround.

It was also the last caller of `execute_with_broker` in this module — opening a second `RequestContext` and session inside a request that already has one, the same misuse #179 removed from the padding path. That import goes with it, along with a duplicated `RequestContext` import the file has carried since the `services/` move.

The `blocked_origins` TODO added in #179 pointed at this function as the worked example of parsing `feed_settings`. It now spells the three lines out inline instead, so the note survives the deletion.

## Verification

- All five CI splits: **431 passed, 9 skipped** — unchanged from main.
- Both architecture ratchets pass.
- `app.openapi()` byte-identical to main.
- mypy one error better than main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)