### PR TITLE
activity: backfill subject_user_id from event_json (step 4 item 1, step 3)

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -172,3 +172,43 @@ jobs:
           set -euo pipefail
           PYTHONPATH=$PWD alembic check
         '
+
+    - name: Backfill round-trips activity.subject_user_id
+      # This job owns the only populated database in CI, which is what a
+      # backfill needs. Since #178 the seed writes subject_user_id on every
+      # row, so running the script as-is would find nothing and pass without
+      # proving anything -- the column is nulled first to recreate the state
+      # production is actually in, and the assertion is that the script puts
+      # back exactly what events.distribute wrote.
+      run: |
+        set -euo pipefail
+        set -a; source env.ci; set +a
+        nix develop --command bash -c '
+          set -euo pipefail
+          export PYTHONPATH=$PWD
+          # chr(58)/chr(44)/chr(45) stand in for : , and - so this stays free of
+          # the single quotes that would end the surrounding bash -c string.
+          fingerprint="select md5(string_agg(id || chr(58) || coalesce(subject_user_id::text, chr(45)), chr(44) order by id)) from activity"
+          before_fp=$(psql "$DATABASE_URL" -tAc "$fingerprint")
+          before=$(psql "$DATABASE_URL" -tAc "select count(subject_user_id) from activity")
+          if [ "$before" -eq 0 ]; then
+            echo "::error::the seed left no populated subjects; this step would prove nothing"
+            exit 1
+          fi
+          psql "$DATABASE_URL" -c "update activity set subject_user_id = null;"
+
+          python scripts/backfill_activity_subject.py --dry-run
+          wrote=$(psql "$DATABASE_URL" -tAc "select count(subject_user_id) from activity")
+          if [ "$wrote" -ne 0 ]; then
+            echo "::error::--dry-run wrote to the database"
+            exit 1
+          fi
+
+          python scripts/backfill_activity_subject.py
+          after_fp=$(psql "$DATABASE_URL" -tAc "$fingerprint")
+          if [ "$before_fp" != "$after_fp" ]; then
+            echo "::error::backfill did not restore what events.distribute wrote"
+            exit 1
+          fi
+          python -m smoke.dataset verify --deep
+        '

--- a/chafan_core/tests/app/test_backfill_activity_subject.py
+++ b/chafan_core/tests/app/test_backfill_activity_subject.py
@@ -1,0 +1,234 @@
+"""The step-3 backfill, against rows events.distribute actually wrote.
+
+The strong assertion is round-trip: null the column on real rows, run the
+backfill, and get back exactly what `distribute` put there. That makes the test
+self-checking rather than a restatement of the extraction, and it stays honest
+as verbs are added -- nothing here names a verb.
+"""
+
+import datetime
+import importlib.util
+import pathlib
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from chafan_core.app import crud, models
+from chafan_core.app.infra.request_context import RequestContext
+from chafan_core.app.schemas.event import CreateQuestionInternal, EventInternal
+from chafan_core.app.schemas.question import QuestionCreate
+from chafan_core.app.schemas.site import SiteCreate
+from chafan_core.app.schemas.user import UserCreate
+from chafan_core.app.services import events
+from chafan_core.tests.utils.utils import (
+    random_email,
+    random_password,
+    random_short_lower_string,
+)
+
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "backfill_activity_subject.py"
+)
+
+
+def _load_script():
+    """Import the script by path -- scripts/ is not a package."""
+    spec = importlib.util.spec_from_file_location("backfill_activity_subject", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backfill_script = _load_script()
+
+
+@pytest.fixture
+def ctx(db: Session):
+    context = RequestContext()
+    context.db = db
+    yield context
+
+
+def _user(db: Session):
+    return crud.user.create(
+        db,
+        obj_in=UserCreate(
+            email=random_email(),
+            password=random_password(),
+            handle=random_short_lower_string(),
+        ),
+    )
+
+
+def _activity(ctx: RequestContext, author):
+    """One Activity, written the way the application writes them."""
+    db = ctx.get_db()
+    site = crud.site.create_with_permission_type(
+        db,
+        obj_in=SiteCreate(
+            name=f"S {random_short_lower_string()}",
+            subdomain=random_short_lower_string(),
+            description="d",
+            permission_type="public",
+        ),
+        moderator=author,
+        category_topic_id=None,
+    )
+    question = crud.question.create_with_author(
+        db,
+        obj_in=QuestionCreate(
+            site_uuid=site.uuid, title=f"Q {random_short_lower_string()}"
+        ),
+        author_id=author.id,
+    )
+    db.flush()
+    activity = events.distribute(
+        ctx,
+        EventInternal(
+            created_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            content=CreateQuestionInternal(
+                subject_id=author.id, question_id=question.id
+            ),
+        ),
+    )
+    db.flush()
+    assert activity is not None
+    return activity
+
+
+def test_round_trips_what_distribute_wrote(ctx: RequestContext) -> None:
+    """Null the column on real rows; the backfill must restore it exactly."""
+    db = ctx.get_db()
+    author = _user(db)
+    written = {
+        a.id: a.subject_user_id for a in (_activity(ctx, author) for _ in range(3))
+    }
+    assert all(
+        v is not None for v in written.values()
+    ), "step 2 should have filled these"
+
+    for activity_id in written:
+        db.query(models.Activity).filter_by(id=activity_id).update(
+            {"subject_user_id": None}
+        )
+    db.flush()
+
+    backfill_script.backfill(db, batch_size=2)
+
+    restored = {
+        a.id: a.subject_user_id
+        for a in db.query(models.Activity).filter(models.Activity.id.in_(list(written)))
+    }
+    assert restored == written
+
+
+def test_dry_run_writes_nothing(ctx: RequestContext) -> None:
+    db = ctx.get_db()
+    author = _user(db)
+    activity = _activity(ctx, author)
+    activity_id = activity.id
+    db.query(models.Activity).filter_by(id=activity_id).update(
+        {"subject_user_id": None}
+    )
+    db.flush()
+
+    stats = backfill_script.backfill(db, dry_run=True)
+
+    assert stats["filled"] >= 1, "a dry run still reports what it would do"
+    assert (
+        db.query(models.Activity).filter_by(id=activity_id).one().subject_user_id
+        is None
+    ), "a dry run must leave the column untouched"
+
+
+def test_rerunning_fills_nothing_further(ctx: RequestContext) -> None:
+    """Idempotent: a second pass has nothing left to fill.
+
+    Note `filled`, not `scanned`. Rows that can never be filled -- unreadable
+    payload, vanished subject -- stay null by design, so every later run
+    re-examines them. That is the cost of not marking them, and at production
+    scale it is nothing.
+    """
+    db = ctx.get_db()
+    author = _user(db)
+    activity = _activity(ctx, author)
+    db.query(models.Activity).filter_by(id=activity.id).update(
+        {"subject_user_id": None}
+    )
+    db.flush()
+
+    first = backfill_script.backfill(db)
+    second = backfill_script.backfill(db)
+
+    assert first["filled"] >= 1
+    assert second["filled"] == 0, "nothing fillable is left after the first pass"
+
+
+def test_unreadable_payload_is_skipped_not_fatal(ctx: RequestContext) -> None:
+    """One retired code path's row must not stop the rest of the table."""
+    db = ctx.get_db()
+    author = _user(db)
+    broken = _activity(ctx, author)
+    intact = _activity(ctx, author)
+    intact_subject = intact.subject_user_id
+    db.query(models.Activity).filter_by(id=broken.id).update(
+        {"subject_user_id": None, "event_json": "this is not json"}
+    )
+    db.query(models.Activity).filter_by(id=intact.id).update({"subject_user_id": None})
+    db.flush()
+
+    stats = backfill_script.backfill(db)
+
+    assert stats["skipped_unreadable"] >= 1
+    assert (
+        db.query(models.Activity).filter_by(id=broken.id).one().subject_user_id is None
+    ), "an unreadable row stays null"
+    assert (
+        db.query(models.Activity).filter_by(id=intact.id).one().subject_user_id
+        == intact_subject
+    ), "the readable row beside it is still filled"
+
+
+def test_vanished_subject_is_skipped_not_fatal(ctx: RequestContext) -> None:
+    """The other reason the column is nullable."""
+    db = ctx.get_db()
+    author = _user(db)
+    activity = _activity(ctx, author)
+    missing_id = db.query(func.max(models.User.id)).scalar() + 1
+    payload = activity.event_json.replace(
+        f'"subject_id":{author.id}', f'"subject_id":{missing_id}'
+    )
+    assert payload != activity.event_json, "the payload shape changed; fix this test"
+    db.query(models.Activity).filter_by(id=activity.id).update(
+        {"subject_user_id": None, "event_json": payload}
+    )
+    db.flush()
+
+    stats = backfill_script.backfill(db)
+
+    assert stats["skipped_missing_user"] >= 1
+    assert (
+        db.query(models.Activity).filter_by(id=activity.id).one().subject_user_id
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ('{"created_at":"x","content":{"verb":"v","subject_id":7}}', 7),
+        ('{"content":{"verb":"v"}}', None),
+        ('{"content":{"verb":"v","subject_id":"7"}}', None),
+        ('{"content":null}', None),
+        ('{"no_content":1}', None),
+        ("not json at all", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_subject_id_extraction(payload, expected) -> None:
+    assert backfill_script.subject_id_of(payload) == expected

--- a/docs/proposals/2026-08-04-activity-feed-reassignment.md
+++ b/docs/proposals/2026-08-04-activity-feed-reassignment.md
@@ -175,32 +175,67 @@ Both live in `test_events_distribute.py`, which — along with
 files one by one and was last touched in #155, before #167 added them. That
 step now takes everything directly under `tests/app/`, by subtraction.
 
-**3. Backfill.** Parse `event_json` for every row where `subject_user_id IS
-NULL`, extract `subject_id`, write it. Batched and idempotent, so it can be run,
-interrupted, and re-run. Note this is a *different* kind of migration from the
-one declined in 3b: that was refusing to **correct** wrong rows, this
-**derives** a column from data that is already right. Size it first:
+**3. Backfill. — done, `scripts/backfill_activity_subject.py`.** Parse
+`event_json` for every row where `subject_user_id IS NULL`, extract
+`subject_id`, write it. Batched and idempotent, so it can be run, interrupted,
+and re-run. Note this is a *different* kind of migration from the one declined
+in 3b: that was refusing to **correct** wrong rows, this **derives** a column
+from data that is already right.
 
-```sql
-SELECT count(*) FROM activity;
-```
+A script rather than a migration, deliberately: it keeps a potentially long
+`UPDATE` out of the migration chain, and an interrupted run is resumed by
+running it again rather than by a downgrade. It is meant to be deleted once
+production has no null subjects left.
+
+### What production actually looks like
+
+Measured 2026-08-06, and it settles most of what this section used to leave
+open:
+
+| | |
+|---|---|
+| rows | 412 (344 kB), oldest 2025-07-06 |
+| `subject_user_id` populated | 0 — step 2 was merged but **not yet deployed** |
+| payloads that will not parse | 0 |
+| payloads with no `subject_id` | 0 |
+| subjects naming a deleted user | 0 |
+| verbs present | 10 of the 15 |
+
+At 412 rows this is a single statement that finishes instantly; the batching
+exists for the table this becomes, not the table it is. Every row is readable
+and every subject resolves, so the skip paths below are — today — defensive
+rather than load-bearing. They stay, because "today" is the wrong thing to
+build a data migration on.
+
+Because step 2 is not deployed yet, **run the script after that deploy**, or
+run it again afterwards: anything written while the old code is still live
+lands with a null subject.
 
 **It must skip, not abort.** A row whose payload will not parse, or whose
 `subject_id` names a user that no longer exists, is left null and logged. One
 unreadable row from some retired code path must not fail the migration for the
 whole table — the same reasoning as 3b-1, one layer down.
 
-The migrations CI exercises this for real: its seeded dataset builds
-`Activity` rows through `events.distribute`, so a backfill runs against genuine
-`event_json` and `verify` fails if it mangles them.
+This is also why the extraction is Python rather than
+`event_json::jsonb -> 'content' ->> 'subject_id'` in SQL: the cast raises on
+the first malformed row and takes the whole statement with it, and
+`pg_input_is_valid` is PostgreSQL 16+ while production is 14.
 
-Coverage is thin, though — `_build_deep` in
-[`smoke/dataset/__init__.py`](../../smoke/dataset/__init__.py) distributes only
-`create_question` and `answer_question`, 2 of the 15 verbs that write
-activities. All 15 store `subject_id` the same way, so one extraction handles
-them all and the risk is lower than the count suggests, but broadening the
-seeded verbs before this step lands would make the test mean what it appears to
-mean.
+### How it is tested
+
+The migrations CI owns the only populated database in CI, which is what a
+backfill needs — but since step 2 the seed writes `subject_user_id` on every
+row, so running the script there as-is would find nothing to do and pass
+without proving anything. The job nulls the column first to recreate the state
+production is in, then asserts the script restores a fingerprint of exactly
+what `events.distribute` wrote.
+
+That construction also dissolves what this section used to flag as thin
+coverage. The test no longer depends on how many verbs `_build_deep` seeds,
+because it never names a verb: it compares the backfill's output against the
+application's own writes, whatever those happen to be. Widening the seeded
+verbs is still worth doing for its own sake, but it is no longer a
+prerequisite here.
 
 **4. Switch the read path.** `get_activities_v2` splits in two, because they
 were always two questions:
@@ -230,9 +265,10 @@ deliberately rather than discovering:
 Keeping the API parameter a uuid is deliberate: it is the public identifier and
 changing it would break clients for no gain.
 
-**5. Delete the dead v1.** `get_activities` has no callers and is already marked
-`# TODO to remove this function`. Same category as `new_activity_into_feed`,
-which #169 deleted.
+**5. Delete the dead v1. — done, #180.** `get_activities` had no callers and was
+already marked `# TODO to remove this function`. Same category as
+`new_activity_into_feed`, which #169 deleted. It was also the last caller of
+`execute_with_broker` in `feed_impl`.
 
 **6. Deferred — drop `feed.subject_user_uuid`.** Destructive DDL, and
 contingent on step 4 item 2 (fan-out-on-write vs read-time resolution): under
@@ -269,11 +305,12 @@ Three tests the change should carry:
 
 ## Open questions
 
-- **Backfill size.** Unknown without `count(*)` against production. It sets
-  whether step 3 is a single statement or a batched script.
-- **Widen the seeded verbs before step 3?** `_build_deep` covers 2 of the 15
-  activity-writing verbs. Cheap to extend, and it is what makes the backfill
-  test load-bearing rather than decorative.
+- ~~**Backfill size.**~~ Answered 2026-08-06: 412 rows, 344 kB. Step 3 is a
+  script for the shape of the job, not for the size of it.
+- ~~**Widen the seeded verbs before step 3?**~~ No longer a prerequisite — the
+  backfill test compares against what `events.distribute` wrote rather than
+  against a fixed list of verbs, so it is load-bearing at any seed width. Still
+  worth doing on its own merits.
 - **Does the subject timeline want a site filter of its own?** Today the viewer
   gate is per item, applied after the fetch, so a subject with lots of activity
   in sites the viewer cannot read yields a short page rather than an empty one.

--- a/scripts/backfill_activity_subject.py
+++ b/scripts/backfill_activity_subject.py
@@ -1,0 +1,195 @@
+"""Fill activity.subject_user_id from event_json for rows written before it existed.
+
+Step 3 of docs/proposals/2026-08-04-activity-feed-reassignment.md. Step 1 added
+the column empty and step 2 populates it on write, so every row predating that
+deploy has a null subject. Step 4 queries subject timelines by this column with
+no fallback, so those rows would simply stop appearing on profiles. This puts
+them back.
+
+Nothing new is derived. The subject is already recorded on every one of those
+rows, inside event_json at content.subject_id; this lifts it into the column so
+it is expressible in SQL.
+
+Safe to interrupt, safe to re-run
+---------------------------------
+Only rows WHERE subject_user_id IS NULL are touched, so a second run is a no-op
+over what the first one finished, and a run killed halfway leaves committed
+batches done and the rest still null. event_json is never written. To undo the
+whole thing: UPDATE activity SET subject_user_id = NULL.
+
+Skips, never aborts
+-------------------
+A row whose payload will not parse, or whose subject_id names a user that no
+longer exists, is counted and left null rather than failing the run. One
+unreadable row from some retired code path must not stop the other 411. Both
+outcomes are why the column is nullable.
+
+Such rows are not marked, so every later run re-examines them -- `filled` goes
+to zero on a second pass but `scanned` does not. At the size this table is,
+that costs nothing and it keeps the script stateless.
+
+Parsing happens in Python rather than as `event_json::jsonb` in SQL for that
+reason: the cast raises on the first malformed row and takes the whole
+statement with it, and pg_input_is_valid is PostgreSQL 16+ (production is 14).
+
+Usage
+-----
+    python scripts/backfill_activity_subject.py --dry-run
+    python scripts/backfill_activity_subject.py
+
+Run it *after* deploying the step-2 code, or run it again afterwards: anything
+written while the old code is still live lands with a null subject.
+"""
+
+import os.path
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import argparse
+import json
+import logging
+from collections import Counter
+from typing import List, Optional, Set, Tuple
+
+from sqlalchemy.orm import Session
+
+from chafan_core.app import models
+from chafan_core.db.session import SessionLocal
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("backfill_activity_subject")
+
+DEFAULT_BATCH_SIZE = 1000
+
+
+def subject_id_of(event_json: Optional[str]) -> Optional[int]:
+    """The subject recorded in a payload, or None if it cannot be read.
+
+    Tolerant on purpose -- a payload that is not JSON, not an object, missing
+    content, missing subject_id, or carrying a non-integer one all yield None
+    and are skipped by the caller.
+    """
+    try:
+        content = json.loads(event_json or "")["content"]
+    except Exception:
+        return None
+    if not isinstance(content, dict):
+        return None
+    subject_id = content.get("subject_id")
+    return subject_id if isinstance(subject_id, int) else None
+
+
+def _existing_user_ids(db: Session, user_ids: Set[int]) -> Set[int]:
+    if not user_ids:
+        return set()
+    rows = db.query(models.User.id).filter(models.User.id.in_(user_ids)).all()
+    return {row[0] for row in rows}
+
+
+def backfill(
+    db: Session, *, batch_size: int = DEFAULT_BATCH_SIZE, dry_run: bool = False
+) -> Counter:
+    """Walk the null-subject rows in id order, filling what can be resolved."""
+    stats: Counter = Counter()
+    after_id = 0
+
+    while True:
+        batch: List[models.Activity] = (
+            db.query(models.Activity)
+            .filter(
+                models.Activity.subject_user_id.is_(None),
+                models.Activity.id > after_id,
+            )
+            .order_by(models.Activity.id)
+            .limit(batch_size)
+            .all()
+        )
+        if not batch:
+            break
+        after_id = batch[-1].id
+
+        pending: List[Tuple[models.Activity, int]] = []
+        for activity in batch:
+            stats["scanned"] += 1
+            subject_id = subject_id_of(activity.event_json)
+            if subject_id is None:
+                stats["skipped_unreadable"] += 1
+                logger.warning("activity %s: no readable subject", activity.id)
+                continue
+            pending.append((activity, subject_id))
+
+        # One lookup per batch rather than one per row: the subjects repeat.
+        live_user_ids = _existing_user_ids(db, {sid for _, sid in pending})
+        # A SAVEPOINT rather than a plain rollback for --dry-run: this function
+        # is handed a Session it does not own, and undoing the caller's other
+        # uncommitted work to unwind our own would be a surprising thing for a
+        # dry run to do.
+        savepoint = db.begin_nested()
+        for activity, subject_id in pending:
+            if subject_id not in live_user_ids:
+                stats["skipped_missing_user"] += 1
+                logger.warning(
+                    "activity %s: subject %s no longer exists", activity.id, subject_id
+                )
+                continue
+            activity.subject_user_id = subject_id
+            stats["filled"] += 1
+
+        db.flush()
+        if dry_run:
+            savepoint.rollback()
+        else:
+            savepoint.commit()
+            db.commit()
+        logger.info(
+            "scanned %s rows so far (through id %s)", stats["scanned"], after_id
+        )
+
+    return stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change, then roll back without writing",
+    )
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        remaining_before = (
+            db.query(models.Activity)
+            .filter(models.Activity.subject_user_id.is_(None))
+            .count()
+        )
+        logger.info(
+            "%s activities have no subject%s",
+            remaining_before,
+            " (dry run: nothing will be written)" if args.dry_run else "",
+        )
+        stats = backfill(db, batch_size=args.batch_size, dry_run=args.dry_run)
+        logger.info(
+            "scanned=%s filled=%s skipped_unreadable=%s skipped_missing_user=%s",
+            stats["scanned"],
+            stats["filled"],
+            stats["skipped_unreadable"],
+            stats["skipped_missing_user"],
+        )
+        if not args.dry_run:
+            remaining_after = (
+                db.query(models.Activity)
+                .filter(models.Activity.subject_user_id.is_(None))
+                .count()
+            )
+            logger.info("%s activities still have no subject", remaining_after)
+    finally:
+        db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Step 3 of [`docs/proposals/2026-08-04-activity-feed-reassignment.md`](https://github.com/chafan-dev/chafan-core/blob/main/docs/proposals/2026-08-04-activity-feed-reassignment.md). Depends on nothing; #180 is independent.

Step 1 added the column empty and step 2 fills it on write, so every row predating that deploy has a null subject. Step 4 queries subject timelines by this column with **no fallback branch**, so shipping it first would truncate every profile to the post-deploy era — a worse regression than the empty-profile bug the plan exists to fix.

Nothing new is derived: the subject is already on every one of those rows, inside `event_json` at `content.subject_id`. This lifts it into the column.

A **script**, not an alembic revision — it keeps a potentially long `UPDATE` out of the migration chain, an interrupted run resumes by running it again rather than by a downgrade, and it can be deleted once production has no null subjects left.

## Production, measured first

| | |
|---|---|
| rows | 412 (344 kB), oldest 2025-07-06 |
| `subject_user_id` populated | **0** — step 2 merged but **not yet deployed** |
| unparseable payloads | 0 |
| payloads with no `subject_id` | 0 |
| subjects naming a deleted user | 0 |
| verbs present | 10 of 15 |

At 412 rows this is one statement that finishes instantly; the batching is for the table it becomes. Every row is readable and every subject resolves, so the skip paths are today **defensive rather than load-bearing**. They stay — "today" is the wrong thing to build a data migration on.

⚠️ **Because step 2 is not deployed, run the script after that deploy** (or again afterwards): anything written while the old code is live lands with a null subject.

## Design notes

**Parsing is Python, not `event_json::jsonb` in SQL.** The cast raises on the first malformed row and takes the whole statement with it, and `pg_input_is_valid` is PG16+ while production is 14. Same reason the sizing probe avoided it.

**`--dry-run` unwinds through a SAVEPOINT, not `db.rollback()`.** `backfill()` is handed a Session it does not own, and discarding the caller's other uncommitted work to undo its own is a surprising thing for a dry run to do. The test caught this by having its own fixtures deleted underneath it.

**Idempotence is over `filled`, not `scanned`.** Rows that can never be filled stay null and are re-examined by every later run. That keeps the script stateless and costs nothing at this size.

## Tested two ways

**13 unit tests.** The strongest nulls the column on rows `events.distribute` actually wrote and asserts the backfill restores them exactly — self-checking, and it never names a verb. Plus the skip paths (unreadable payload beside an intact row; vanished subject) and a parametrised table over eight payload shapes.

**A migrations-CI step**, because that job owns the only populated database in CI. Since step 2 the seed fills every row, so running the script there as-is would find nothing and pass vacuously — the step nulls the column first to recreate production's state, proves `--dry-run` wrote nothing, then compares an md5 fingerprint of every `(id, subject)` pair against what `distribute` wrote.

I ran that step **verbatim** against a from-scratch seeded database, and separately confirmed the fingerprint changes when the column is nulled, so the comparison isn't vacuous.

That construction also closes the proposal's **"widen the seeded verbs"** open question: the test compares against the application's own writes rather than a fixed verb list, so it's load-bearing at any seed width.

## Verification

- All five CI splits: **444 passed, 9 skipped** — up from 431 by the 13 added here.
- Both architecture ratchets pass.
- `app.openapi()` byte-identical to main.
- `black --check` clean on both new files.
- mypy reports three `Column[...]` false positives in the script, the same kind the untyped models produce throughout; `lint.sh` doesn't check `scripts/` in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)